### PR TITLE
[BE] chore: local환경과 배포환경의 yml설정을 분리

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,4 @@
+### application-local.yml 로 실행하는 방법
+1. `Edit Configurations` 들어가기
+2. `TernokoApplication`의 `Active Profiles`에 `local` 입력
+3. `apply` 후 `OK`

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,4 +1,0 @@
-### application-local.yml 로 실행하는 방법
-1. `Edit Configurations` 들어가기
-2. `TernokoApplication`의 `Active Profiles`에 `local` 입력
-3. `apply` 후 `OK`

--- a/backend/src/main/java/com/woowacourse/ternoko/config/DatabaseInitializer.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/config/DatabaseInitializer.java
@@ -1,0 +1,63 @@
+package com.woowacourse.ternoko.config;
+
+import java.util.ArrayList;
+
+import javax.annotation.PostConstruct;
+
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.woowacourse.ternoko.domain.member.Coach;
+import com.woowacourse.ternoko.repository.CoachRepository;
+
+import lombok.RequiredArgsConstructor;
+
+// TODO: dev ddl 수정되면 @Profile("local") 설정필요
+@Component
+@RequiredArgsConstructor
+public class DatabaseInitializer {
+    private static final String TEST_EMAIL = "test@email.com";
+
+    private final InitService initService;
+
+    @PostConstruct
+    public void init() {
+        initService.dbInit();
+    }
+
+    @Component
+    @Transactional
+    @RequiredArgsConstructor
+    static class InitService {
+        private final CoachRepository coachRepository;
+
+        public void dbInit() {
+            ArrayList<Coach> coaches = new ArrayList<>(12);
+            coaches.add(new Coach(1L, "공원", TEST_EMAIL,
+                "https://user-images.githubusercontent.com/26570275/177680173-9bb25eac-5922-407b-889b-bb49ac392c2a.png"));
+            coaches.add(new Coach(2L, "네오", TEST_EMAIL,
+                "https://user-images.githubusercontent.com/26570275/177680191-a4497404-c4cb-4f86-8c2c-f4f9c70bcaf7.png"));
+            coaches.add(new Coach(3L, "브라운", TEST_EMAIL,
+                "https://user-images.githubusercontent.com/26570275/177680196-744300be-eb1b-4331-a74f-fdc41ff869d0.png"));
+            coaches.add(new Coach(4L, "브리", TEST_EMAIL,
+                "https://user-images.githubusercontent.com/43205258/177765431-63d39896-c8e1-42e8-a229-08309849f2ff.png"));
+            coaches.add(new Coach(5L, "왼손", TEST_EMAIL,
+                "https://user-images.githubusercontent.com/26570275/177680204-6d12cae9-f038-4503-b9de-a75f4b4de456.png"));
+            coaches.add(new Coach(6L, "워니", TEST_EMAIL,
+                "https://user-images.githubusercontent.com/26570275/177680207-896f887b-5baf-47a5-b7ea-3b8c1bb5b8c3.png"));
+            coaches.add(new Coach(7L, "제이슨", TEST_EMAIL,
+                "https://user-images.githubusercontent.com/43205258/177760748-5e0e9efd-d063-4639-9a6d-f48e3a76f919.png"));
+            coaches.add(new Coach(8L, "준", TEST_EMAIL,
+                "https://user-images.githubusercontent.com/26570275/177680212-63242449-1059-450b-96d8-a06b01a1aea5.png"));
+            coaches.add(new Coach(9L, "토미", TEST_EMAIL,
+                "https://user-images.githubusercontent.com/26570275/177680217-764aa425-72cb-4b04-adeb-f110121cdf60.png"));
+            coaches.add(new Coach(10L, "포비", TEST_EMAIL,
+                "https://user-images.githubusercontent.com/26570275/177680220-fd4258be-d317-4080-a6f6-eaaa58beef0e.png"));
+            coaches.add(new Coach(11L, "구구", TEST_EMAIL,
+                "https://user-images.githubusercontent.com/43205258/177739511-d427cb0c-5a8d-4bfb-9df1-945b4d32afb4.png"));
+            coaches.add(new Coach(12L, "포코", TEST_EMAIL,
+                "https://user-images.githubusercontent.com/54317630/177786158-226652b7-7b4a-462c-af3b-775811756c87.png"));
+            coachRepository.saveAll(coaches);
+        }
+    }
+}

--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -1,0 +1,23 @@
+spring:
+  config:
+    activate:
+      on-profile: dev
+  jpa:
+    show-sql: true
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        format_sql: true
+  datasource:
+    url: jdbc:mysql://localhost:3306/ternoko?serverTimezone=Asia/Seoul
+    username: root
+    password:
+logging:
+  level:
+    org:
+      hibernate:
+        type:
+          descriptor:
+            sql:
+              BasicBinder: TRACE

--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -11,8 +11,8 @@ spring:
         format_sql: true
   datasource:
     url: jdbc:mysql://localhost:3306/ternoko?serverTimezone=Asia/Seoul
-    username: root
-    password:
+    username: ${TERNOKO_MYSQL_ID}
+    password: ${TERNOKO_MYSQL_PASSWORD}
 logging:
   level:
     org:

--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -5,7 +5,7 @@ spring:
   jpa:
     show-sql: true
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     properties:
       hibernate:
         format_sql: true

--- a/backend/src/main/resources/application-local.yml
+++ b/backend/src/main/resources/application-local.yml
@@ -1,0 +1,25 @@
+spring:
+  config:
+    activate:
+      on-profile: local
+  jpa:
+    show-sql: true
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        format_sql: true
+  datasource:
+    url: jdbc:h2:~/test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;MODE=MySQL
+    username: sa
+  h2:
+    console:
+      enabled: true
+logging:
+  level:
+    org:
+      hibernate:
+        type:
+          descriptor:
+            sql:
+              BasicBinder: TRACE

--- a/backend/src/main/resources/application-local.yml
+++ b/backend/src/main/resources/application-local.yml
@@ -5,13 +5,14 @@ spring:
   jpa:
     show-sql: true
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: create
     properties:
       hibernate:
         format_sql: true
   datasource:
-    url: jdbc:h2:~/test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;MODE=MySQL
-    username: sa
+    url: jdbc:mysql://localhost:3306/ternoko?serverTimezone=Asia/Seoul
+    username: root
+    password:
   h2:
     console:
       enabled: true

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -1,3 +1,5 @@
 spring:
   profiles:
-    default: dev
+    default: local
+server:
+  port: 8082

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -1,5 +1,3 @@
 spring:
   profiles:
     default: local
-server:
-  port: 8082

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -1,24 +1,3 @@
 spring:
-  jpa:
-    show-sql: true
-    hibernate:
-      ddl-auto: none
-    properties:
-      hibernate:
-        format_sql: true
-    generate-ddl: true
-  datasource:
-    url: jdbc:h2:~/test5;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;MODE=MySQL
-    username: sa
-  h2:
-    console:
-      enabled:
-        true
-logging:
-  level:
-    org:
-      hibernate:
-        type:
-          descriptor:
-            sql:
-              BasicBinder: TRACE
+  profiles:
+    default: dev


### PR DESCRIPTION
### Issues
- [x] #61 

### 논의사항
- [ ] ~~backend/README.md 에 있는 설정대로 하면 local로 잘 실행되는지 확인 바랍니다.~~
- [ ] ~~test도 test/resource/application.yml 로 실행이 잘 되는지도 확인 바랍니다.~~
- [x] 배포서버에 환경변수로 mysql user의 id, password를 등록했고 mysql로 실행 잘 되는 것 확인했습니다.
- [ ] ~~local에서 appliocation-dev.yml도 구동되는지 확인해보려 했는데 저는 잘 안되었습니다.~~
   - `java.sql.SQLException: Access denied for user '${TERNOKO_MYSQL_ID}'@'localhost' (using password: YES)` 발생

### 추가된 논의사항
- [ ] default는 local로 설정했습니다.
- [ ] dev도 현재는 ddl:create 입니다. 필드가 아직 많이 바뀌는 상황이라서 sprint2까지는 local, dev 둘다 create로 가려구요!
- [ ] Database initializer 추가했습니다. 
   - 매번 서버띄울때마다 코치 쿼리 날려줬어야해서 너무 불편해서 일단 추가했어요

close #61 


