### PR TITLE
[BE] feat: 되는 시간 정렬 후 반환 로직 구현

### DIFF
--- a/backend/src/main/java/com/woowacourse/ternoko/controller/MemberController.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/controller/MemberController.java
@@ -39,10 +39,9 @@ public class MemberController {
     }
 
     @GetMapping("/coaches/{coachId}/calendar/times")
-    public ResponseEntity<AvailableDateTimesResponse> findCalendarTimes(
-        @PathVariable final Long coachId,
-        @RequestParam final int year,
-        @RequestParam final int month) {
+    public ResponseEntity<AvailableDateTimesResponse> findCalendarTimes(@PathVariable final Long coachId,
+                                                                        @RequestParam final int year,
+                                                                        @RequestParam final int month) {
         final List<AvailableDateTime> availableDateTimes = coachService
             .findAvailableDateTimesByCoachId(coachId, year, month);
         final AvailableDateTimesResponse from = AvailableDateTimesResponse.from(availableDateTimes);

--- a/backend/src/main/java/com/woowacourse/ternoko/dto/AvailableDateTimesResponse.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/dto/AvailableDateTimesResponse.java
@@ -20,6 +20,7 @@ public class AvailableDateTimesResponse {
     public static AvailableDateTimesResponse from(final List<AvailableDateTime> availableDateTimes) {
         return new AvailableDateTimesResponse(availableDateTimes.stream()
                 .map(AvailableDateTime::getLocalDateTime)
+                .sorted()
                 .collect(Collectors.toList()));
     }
 }

--- a/backend/src/main/java/com/woowacourse/ternoko/service/ReservationService.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/service/ReservationService.java
@@ -72,6 +72,7 @@ public class ReservationService {
     }
 
     private void validateInterviewStartTime(final LocalDateTime localDateTime) {
+        //TODO: 날짜 컨트롤러에서 받아서 검증하는걸로 변경
         final LocalDate standardDay = LocalDate.now().plusDays(1);
         if (!standardDay.isBefore(localDateTime.toLocalDate())) {
             throw new IllegalArgumentException(INVALID_LOCAL_DATE_TIME_EXCEPTION_MESSAGE);

--- a/backend/src/test/java/com/woowacourse/ternoko/acceptance/MemberAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/ternoko/acceptance/MemberAcceptanceTest.java
@@ -1,21 +1,26 @@
 package com.woowacourse.ternoko.acceptance;
 
-import static com.woowacourse.ternoko.fixture.MemberFixture.*;
-import static org.assertj.core.api.Assertions.*;
-
-import java.util.List;
-
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.springframework.http.HttpStatus;
+import static com.woowacourse.ternoko.fixture.MemberFixture.AVAILABLE_DATE_TIME_REQUEST2;
+import static com.woowacourse.ternoko.fixture.MemberFixture.AVAILABLE_DATE_TIME_REQUEST3;
+import static com.woowacourse.ternoko.fixture.MemberFixture.AVAILABLE_DATE_TIME_REQUEST4;
+import static com.woowacourse.ternoko.fixture.MemberFixture.AVAILABLE_TIMES;
+import static com.woowacourse.ternoko.fixture.MemberFixture.COACH3;
+import static com.woowacourse.ternoko.fixture.MemberFixture.TIME2;
+import static com.woowacourse.ternoko.fixture.MemberFixture.TIME3;
+import static com.woowacourse.ternoko.fixture.MemberFixture.TIME4;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.woowacourse.ternoko.dto.AvailableDateTimesResponse;
 import com.woowacourse.ternoko.dto.CoachesResponse;
 import com.woowacourse.ternoko.dto.request.AvailableDateTimeRequest;
 import com.woowacourse.ternoko.dto.request.AvailableDateTimesRequest;
-
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
 
 class MemberAcceptanceTest extends AcceptanceTest {
 
@@ -35,15 +40,15 @@ class MemberAcceptanceTest extends AcceptanceTest {
     void saveCalendarTimes() {
         // given
         final AvailableDateTimeRequest AVAILABLEDATETIMEREQUEST = new AvailableDateTimeRequest(
-            TIME2.getYear(),
-            TIME2.getMonthValue(),
-            AVAILABLE_TIMES);
+                TIME2.getYear(),
+                TIME2.getMonthValue(),
+                AVAILABLE_TIMES);
         final AvailableDateTimesRequest availableDateTimesRequest = new AvailableDateTimesRequest(List.of(
-            AVAILABLEDATETIMEREQUEST));
+                AVAILABLEDATETIMEREQUEST));
 
         // when
         final ExtractableResponse<Response> calendarResponse = put("/api/coaches/" + COACH3.getId() + "/calendar/times",
-            availableDateTimesRequest);
+                availableDateTimesRequest);
 
         // then
         assertThat(calendarResponse.statusCode()).isEqualTo(HttpStatus.OK.value());
@@ -54,13 +59,13 @@ class MemberAcceptanceTest extends AcceptanceTest {
     void saveCalendarsTimes() {
         // given
         final AvailableDateTimesRequest availableDateTimesRequest = new AvailableDateTimesRequest(List.of(
-            AVAILABLE_DATE_TIME_REQUEST2,
-            AVAILABLE_DATE_TIME_REQUEST3,
-            AVAILABLE_DATE_TIME_REQUEST4));
+                AVAILABLE_DATE_TIME_REQUEST2,
+                AVAILABLE_DATE_TIME_REQUEST3,
+                AVAILABLE_DATE_TIME_REQUEST4));
 
         // when
         final ExtractableResponse<Response> calendarResponse = put("/api/coaches/" + COACH3.getId() + "/calendar/times",
-            availableDateTimesRequest);
+                availableDateTimesRequest);
 
         // then
         assertThat(calendarResponse.statusCode()).isEqualTo(HttpStatus.OK.value());
@@ -70,12 +75,22 @@ class MemberAcceptanceTest extends AcceptanceTest {
     @DisplayName("코치의 면담 가능 시간을 조회한다.")
     void findCalendarTimes() {
         // given
+        //TODO: Fixture 리팩토링 후 수정
         final AvailableDateTimesRequest availableDateTimesRequest = new AvailableDateTimesRequest(List.of(
-            AVAILABLE_DATE_TIME_REQUEST2));
+                new AvailableDateTimeRequest(
+                        TIME2.getYear(),
+                        TIME2.getMonthValue(),
+                        List.of(
+                                LocalDateTime.of(TIME4.getYear(), TIME4.getMonthValue(),
+                                        TIME4.getDayOfMonth(), TIME4.getHour(), TIME4.getMinute()),
+                                LocalDateTime.of(TIME3.getYear(), TIME3.getMonthValue(),
+                                        TIME3.getDayOfMonth(), TIME3.getHour(), TIME3.getMinute()),
+                                LocalDateTime.of(TIME2.getYear(), TIME4.getMonthValue(),
+                                        TIME2.getDayOfMonth(), TIME2.getHour(), TIME2.getMinute())))));
         put("/api/coaches/" + COACH3.getId() + "/calendar/times", availableDateTimesRequest);
 
         final ExtractableResponse<Response> calendarResponse = get(
-            "/api/coaches/" + COACH3.getId() + "/calendar/times?year=2022&month=7");
+                "/api/coaches/" + COACH3.getId() + "/calendar/times?year=2022&month=7");
 
         // when
         final AvailableDateTimesResponse response = calendarResponse.body().as(AvailableDateTimesResponse.class);
@@ -83,6 +98,12 @@ class MemberAcceptanceTest extends AcceptanceTest {
         // then
         assertThat(response.getCalendarTimes())
                 .hasSize(3)
-                .containsAnyElementsOf(AVAILABLE_DATE_TIME_REQUEST2.getTimes());
+                .containsExactly(LocalDateTime.of(TIME2.getYear(), TIME2.getMonthValue(),
+                        TIME2.getDayOfMonth(), TIME2.getHour(), TIME2.getMinute()),
+                        LocalDateTime.of(TIME3.getYear(), TIME3.getMonthValue(),
+                                TIME3.getDayOfMonth(), TIME3.getHour(), TIME3.getMinute()),
+                        LocalDateTime.of(TIME4.getYear(), TIME4.getMonthValue(),
+                                TIME4.getDayOfMonth(), TIME4.getHour(), TIME4.getMinute())
+                );
     }
 }


### PR DESCRIPTION
### Issues
- #70 
- [x] 코치들의 되는 시간을 반환할때 시간순으로 정렬하여 반환한다. 

### 논의사항
[Fixture 및 테스트코드 리팩토링 이슈](https://github.com/woowacourse-teams/2022-ternoko/issues/72)를 진행하면서 변경될 것 같아 현재 테스트 코드내에 요소들을 변수로 분리하지 않았습니다. 바로 리팩토링 반영할 예정이니 리뷰시 참고해주세요~!

close #70 


