### PR TITLE
[BE] feat: 면담 예약 시 코치 되는 시간에서 삭제 기능 추가

### DIFF
--- a/backend/src/main/java/com/woowacourse/ternoko/common/exception/ExceptionType.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/common/exception/ExceptionType.java
@@ -9,7 +9,8 @@ public enum ExceptionType {
 
     COACH_NOT_FOUND(400, "번째 코치를 찾을 수 없습니다."),
     RESERVATION_NOT_FOUND(400, "번째 면담 예약을 찾을 수 없습니다."),
-    INVALID_RESERVATION_DATE(400, "면담 예약은 최소 하루 전에 가능 합니다.");
+    INVALID_RESERVATION_DATE(400, "면담 예약은 최소 하루 전에 가능 합니다."),
+    INVALID_AVAILABLE_DATE_TIME(400, "선택한 날짜는 해당 코치의 가능한 시간이 아닙니다.");
 
 
     private final int code;

--- a/backend/src/main/java/com/woowacourse/ternoko/repository/AvailableDateTimeRepository.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/repository/AvailableDateTimeRepository.java
@@ -11,7 +11,6 @@ import org.springframework.data.jpa.repository.Query;
 
 public interface AvailableDateTimeRepository extends JpaRepository<AvailableDateTime, Long> {
 
-    @Modifying(clearAutomatically = true)
     @Query("delete from AvailableDateTime a where a.coach.id = :coachId and YEAR(a.localDateTime) = :year and MONTH(a.localDateTime) = :month")
     void deleteAllByCoachAndYearAndMonth(final Long coachId, final int year, final int month);
 

--- a/backend/src/main/java/com/woowacourse/ternoko/repository/AvailableDateTimeRepository.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/repository/AvailableDateTimeRepository.java
@@ -11,6 +11,8 @@ import org.springframework.data.jpa.repository.Query;
 
 public interface AvailableDateTimeRepository extends JpaRepository<AvailableDateTime, Long> {
 
+
+    @Modifying(clearAutomatically = true)
     @Query("delete from AvailableDateTime a where a.coach.id = :coachId and YEAR(a.localDateTime) = :year and MONTH(a.localDateTime) = :month")
     void deleteAllByCoachAndYearAndMonth(final Long coachId, final int year, final int month);
 

--- a/backend/src/main/java/com/woowacourse/ternoko/repository/AvailableDateTimeRepository.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/repository/AvailableDateTimeRepository.java
@@ -14,6 +14,10 @@ public interface AvailableDateTimeRepository extends JpaRepository<AvailableDate
     @Query("delete from AvailableDateTime a where a.coach.id = :coachId and YEAR(a.localDateTime) = :year and MONTH(a.localDateTime) = :month")
     void deleteAllByCoachAndYearAndMonth(final Long coachId, final int year, final int month);
 
+    @Modifying(clearAutomatically = true)
+    @Query("delete from AvailableDateTime a where a.coach.id = :coachId and a.localDateTime = :interviewDateTime")
+    void deleteByCoachIdAndInterviewDateTime(Long coachId, LocalDateTime interviewDateTime);
+
     @Query("select a from AvailableDateTime a where a.coach.id = :coachId and YEAR(a.localDateTime) = :year and MONTH(a.localDateTime) = :month")
     List<AvailableDateTime> findAvailableDateTimesByCoachId(final Long coachId, final int year, final int month);
 }

--- a/backend/src/main/java/com/woowacourse/ternoko/repository/AvailableDateTimeRepository.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/repository/AvailableDateTimeRepository.java
@@ -4,6 +4,7 @@ import com.woowacourse.ternoko.domain.AvailableDateTime;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -14,10 +15,9 @@ public interface AvailableDateTimeRepository extends JpaRepository<AvailableDate
     @Query("delete from AvailableDateTime a where a.coach.id = :coachId and YEAR(a.localDateTime) = :year and MONTH(a.localDateTime) = :month")
     void deleteAllByCoachAndYearAndMonth(final Long coachId, final int year, final int month);
 
-    @Modifying(clearAutomatically = true)
-    @Query("delete from AvailableDateTime a where a.coach.id = :coachId and a.localDateTime = :interviewDateTime")
-    void deleteByCoachIdAndInterviewDateTime(Long coachId, LocalDateTime interviewDateTime);
-
     @Query("select a from AvailableDateTime a where a.coach.id = :coachId and YEAR(a.localDateTime) = :year and MONTH(a.localDateTime) = :month")
     List<AvailableDateTime> findAvailableDateTimesByCoachId(final Long coachId, final int year, final int month);
+
+    @Query("select a from AvailableDateTime a where a.coach.id = :coachId and a.localDateTime = :interviewDateTime")
+    Optional<AvailableDateTime> findByCoachIdAndInterviewDateTime(Long coachId, LocalDateTime interviewDateTime);
 }

--- a/backend/src/main/java/com/woowacourse/ternoko/service/CoachService.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/service/CoachService.java
@@ -1,5 +1,7 @@
 package com.woowacourse.ternoko.service;
 
+import static com.woowacourse.ternoko.common.exception.ExceptionType.*;
+
 import com.woowacourse.ternoko.common.exception.CoachNotFoundException;
 import com.woowacourse.ternoko.common.exception.ExceptionType;
 import com.woowacourse.ternoko.domain.AvailableDateTime;
@@ -43,7 +45,7 @@ public class CoachService {
     public void putAvailableDateTimesByCoachId(final Long coachId,
                                                final AvailableDateTimesRequest availableDateTimesRequest) {
         final Coach coach = coachRepository.findById(coachId)
-                .orElseThrow(() -> new CoachNotFoundException(ExceptionType.COACH_NOT_FOUND, coachId));
+                .orElseThrow(() -> new CoachNotFoundException(COACH_NOT_FOUND, coachId));
 
         final List<AvailableDateTimeRequest> availableDateTimeRequests = availableDateTimesRequest
             .getCalendarTimes();

--- a/backend/src/main/java/com/woowacourse/ternoko/service/ReservationService.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/service/ReservationService.java
@@ -1,5 +1,7 @@
 package com.woowacourse.ternoko.service;
 
+import static com.woowacourse.ternoko.common.exception.ExceptionType.*;
+
 import com.woowacourse.ternoko.common.exception.CoachNotFoundException;
 import com.woowacourse.ternoko.common.exception.ExceptionType;
 import com.woowacourse.ternoko.common.exception.InvalidReservationDateException;
@@ -52,7 +54,7 @@ public class ReservationService {
 
         AvailableDateTime availableDateTime = availableDateTimeRepository.findByCoachIdAndInterviewDateTime(
                         coachId, reservationRequest.getInterviewDatetime())
-                .orElseThrow(() -> new InvalidReservationDateException(ExceptionType.INVALID_AVAILABLE_DATE_TIME));
+                .orElseThrow(() -> new InvalidReservationDateException(INVALID_AVAILABLE_DATE_TIME));
         availableDateTimeRepository.delete(availableDateTime);
 
         return reservationRepository.save(new Reservation(interview, false)).getId();
@@ -62,7 +64,7 @@ public class ReservationService {
         final LocalDateTime reservationDatetime = reservationRequest.getInterviewDatetime();
 
         final Coach coach = coachRepository.findById(coachId)
-                .orElseThrow(() -> new CoachNotFoundException(ExceptionType.COACH_NOT_FOUND, coachId));
+                .orElseThrow(() -> new CoachNotFoundException(COACH_NOT_FOUND, coachId));
 
         validateInterviewStartTime(reservationDatetime);
 
@@ -77,7 +79,7 @@ public class ReservationService {
         //TODO: 날짜 컨트롤러에서 받아서 검증하는걸로 변경
         final LocalDate standardDay = LocalDate.now().plusDays(1);
         if (!standardDay.isBefore(localDateTime.toLocalDate())) {
-            throw new InvalidReservationDateException(ExceptionType.INVALID_RESERVATION_DATE);
+            throw new InvalidReservationDateException(INVALID_RESERVATION_DATE);
         }
     }
 
@@ -91,7 +93,7 @@ public class ReservationService {
     public ReservationResponse findReservationById(final Long reservationId) {
         final Reservation reservation = reservationRepository.findById(reservationId)
                 .orElseThrow(
-                        () -> new ReservationNotFoundException(ExceptionType.RESERVATION_NOT_FOUND, reservationId));
+                        () -> new ReservationNotFoundException(RESERVATION_NOT_FOUND, reservationId));
         return ReservationResponse.from(reservation);
     }
 

--- a/backend/src/main/java/com/woowacourse/ternoko/service/ReservationService.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/service/ReservationService.java
@@ -1,5 +1,6 @@
 package com.woowacourse.ternoko.service;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.woowacourse.ternoko.common.exception.CoachNotFoundException;
 import com.woowacourse.ternoko.common.exception.ExceptionType;
 import com.woowacourse.ternoko.common.exception.InvalidReservationDateException;
@@ -12,6 +13,7 @@ import com.woowacourse.ternoko.dto.ReservationResponse;
 import com.woowacourse.ternoko.dto.ScheduleResponse;
 import com.woowacourse.ternoko.dto.request.FormItemRequest;
 import com.woowacourse.ternoko.dto.request.ReservationRequest;
+import com.woowacourse.ternoko.repository.AvailableDateTimeRepository;
 import com.woowacourse.ternoko.repository.CoachRepository;
 import com.woowacourse.ternoko.repository.InterviewRepository;
 import com.woowacourse.ternoko.repository.ReservationRepository;
@@ -37,6 +39,7 @@ public class ReservationService {
     private final CoachRepository coachRepository;
     private final ReservationRepository reservationRepository;
     private final InterviewRepository interviewRepository;
+    private final AvailableDateTimeRepository availableDateTimeRepository;
 
     public Long create(final Long coachId, final ReservationRequest reservationRequest) {
         final Interview interview = convertInterview(coachId, reservationRequest);
@@ -46,6 +49,8 @@ public class ReservationService {
         for (FormItem formItem : formItems) {
             formItem.addInterview(savedInterview);
         }
+
+        availableDateTimeRepository.deleteByCoachIdAndInterviewDateTime(coachId, reservationRequest.getInterviewDatetime());
 
         return reservationRepository.save(new Reservation(interview, false)).getId();
     }

--- a/backend/src/main/java/com/woowacourse/ternoko/service/ReservationService.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/service/ReservationService.java
@@ -52,8 +52,8 @@ public class ReservationService {
             formItem.addInterview(savedInterview);
         }
 
-        AvailableDateTime availableDateTime = availableDateTimeRepository.findByCoachIdAndInterviewDateTime(
-                        coachId, reservationRequest.getInterviewDatetime())
+        final AvailableDateTime availableDateTime = availableDateTimeRepository
+                .findByCoachIdAndInterviewDateTime(coachId, reservationRequest.getInterviewDatetime())
                 .orElseThrow(() -> new InvalidReservationDateException(INVALID_AVAILABLE_DATE_TIME));
         availableDateTimeRepository.delete(availableDateTime);
 
@@ -92,8 +92,7 @@ public class ReservationService {
     @Transactional(readOnly = true)
     public ReservationResponse findReservationById(final Long reservationId) {
         final Reservation reservation = reservationRepository.findById(reservationId)
-                .orElseThrow(
-                        () -> new ReservationNotFoundException(RESERVATION_NOT_FOUND, reservationId));
+                .orElseThrow(() -> new ReservationNotFoundException(RESERVATION_NOT_FOUND, reservationId));
         return ReservationResponse.from(reservation);
     }
 

--- a/backend/src/main/java/com/woowacourse/ternoko/service/ReservationService.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/service/ReservationService.java
@@ -1,10 +1,10 @@
 package com.woowacourse.ternoko.service;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
 import com.woowacourse.ternoko.common.exception.CoachNotFoundException;
 import com.woowacourse.ternoko.common.exception.ExceptionType;
 import com.woowacourse.ternoko.common.exception.InvalidReservationDateException;
 import com.woowacourse.ternoko.common.exception.ReservationNotFoundException;
+import com.woowacourse.ternoko.domain.AvailableDateTime;
 import com.woowacourse.ternoko.domain.FormItem;
 import com.woowacourse.ternoko.domain.Interview;
 import com.woowacourse.ternoko.domain.Reservation;
@@ -50,7 +50,10 @@ public class ReservationService {
             formItem.addInterview(savedInterview);
         }
 
-        availableDateTimeRepository.deleteByCoachIdAndInterviewDateTime(coachId, reservationRequest.getInterviewDatetime());
+        AvailableDateTime availableDateTime = availableDateTimeRepository.findByCoachIdAndInterviewDateTime(
+                        coachId, reservationRequest.getInterviewDatetime())
+                .orElseThrow(() -> new InvalidReservationDateException(ExceptionType.INVALID_AVAILABLE_DATE_TIME));
+        availableDateTimeRepository.delete(availableDateTime);
 
         return reservationRepository.save(new Reservation(interview, false)).getId();
     }

--- a/backend/src/test/java/com/woowacourse/ternoko/acceptance/AcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/ternoko/acceptance/AcceptanceTest.java
@@ -8,6 +8,7 @@ import io.restassured.RestAssured;
 import io.restassured.http.Header;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import java.time.LocalDateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
@@ -103,8 +104,17 @@ public class AcceptanceTest {
     }
 
     protected ExtractableResponse<Response> createReservation(final Long coachId, final String crewName) {
+        final ReservationRequest reservationRequest = new ReservationRequest(crewName, AFTER_TWO_DAYS,
+                FORM_ITEM_REQUESTS);
+
+        return post("/api/reservations/coaches/" + coachId, reservationRequest);
+    }
+
+    protected ExtractableResponse<Response> createReservation(final Long coachId,
+                                                              final String crewName,
+                                                              final LocalDateTime interviewDateTime) {
         final ReservationRequest reservationRequest = new ReservationRequest(crewName,
-                AFTER_TWO_DAYS,
+                interviewDateTime,
                 FORM_ITEM_REQUESTS);
 
         return post("/api/reservations/coaches/" + coachId, reservationRequest);

--- a/backend/src/test/java/com/woowacourse/ternoko/acceptance/CoachAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/ternoko/acceptance/CoachAcceptanceTest.java
@@ -2,6 +2,7 @@ package com.woowacourse.ternoko.acceptance;
 
 import static com.woowacourse.ternoko.fixture.CoachAvailableTimeFixture.MONTHS_REQUEST;
 import static com.woowacourse.ternoko.fixture.CoachAvailableTimeFixture.MONTH_REQUEST;
+import static com.woowacourse.ternoko.fixture.CoachAvailableTimeFixture.NOW;
 import static com.woowacourse.ternoko.fixture.CoachAvailableTimeFixture.NOW_PLUS_2_DAYS;
 import static com.woowacourse.ternoko.fixture.CoachAvailableTimeFixture.SECOND_TIME;
 import static com.woowacourse.ternoko.fixture.MemberFixture.COACH3;
@@ -55,8 +56,8 @@ public class CoachAcceptanceTest extends AcceptanceTest {
 
         // when
         final ExtractableResponse<Response> response = RestAssured.given().log().all()
-                .queryParam("year", NOW_PLUS_2_DAYS.getYear())
-                .queryParam("month", NOW_PLUS_2_DAYS.getMonthValue())
+                .queryParam("year", NOW.getYear())
+                .queryParam("month", NOW.getMonthValue())
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .when().get("/api/coaches/" + COACH3.getId() + "/schedules")
                 .then().log().all()

--- a/backend/src/test/java/com/woowacourse/ternoko/acceptance/CoachAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/ternoko/acceptance/CoachAcceptanceTest.java
@@ -1,41 +1,69 @@
 package com.woowacourse.ternoko.acceptance;
 
-import static com.woowacourse.ternoko.fixture.MemberFixture.*;
-import static com.woowacourse.ternoko.fixture.ReservationFixture.*;
-import static org.assertj.core.api.Assertions.*;
-
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.springframework.http.MediaType;
+import static com.woowacourse.ternoko.fixture.CoachAvailableTimeFixture.MONTHS_REQUEST;
+import static com.woowacourse.ternoko.fixture.CoachAvailableTimeFixture.MONTH_REQUEST;
+import static com.woowacourse.ternoko.fixture.CoachAvailableTimeFixture.NOW_PLUS_2_DAYS;
+import static com.woowacourse.ternoko.fixture.CoachAvailableTimeFixture.SECOND_TIME;
+import static com.woowacourse.ternoko.fixture.MemberFixture.COACH3;
+import static com.woowacourse.ternoko.fixture.ReservationFixture.FORM_ITEM_REQUESTS;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.woowacourse.ternoko.dto.ScheduleResponse;
-
+import com.woowacourse.ternoko.dto.request.ReservationRequest;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 
 public class CoachAcceptanceTest extends AcceptanceTest {
+    @Test
+    @DisplayName("코치의 면담 가능 시간을 저장한다.")
+    void saveCalendarTimes() {
+        // given & when
+        final ExtractableResponse<Response> calendarResponse = put("/api/coaches/" + COACH3.getId() + "/calendar/times",
+                MONTH_REQUEST);
+
+        // then
+        assertThat(calendarResponse.statusCode()).isEqualTo(HttpStatus.OK.value());
+    }
 
     @Test
-    @DisplayName("코치 - 면담 예약 내역 목록을 조회한다.")
+    @DisplayName("코치의 면담 가능 시간을 저장한다. - 여러 달")
+    void saveCalendarsTimes() {
+        // given & when
+        final ExtractableResponse<Response> calendarResponse = put("/api/coaches/" + COACH3.getId() + "/calendar/times",
+                MONTHS_REQUEST);
+
+        // then
+        assertThat(calendarResponse.statusCode()).isEqualTo(HttpStatus.OK.value());
+    }
+
+    @Test
+    @DisplayName("선택한 년, 월의 면담 예약 내역 목록을 조회한다.")
     void findAllByCoach() {
         // given
-        createReservation(COACH4.getId(), "애쉬");
-        createReservation(COACH4.getId(), "바니");
-        createReservation(COACH4.getId(), "앤지");
-        createReservation(COACH4.getId(), "열음");
+        put("/api/coaches/" + COACH3.getId() + "/calendar/times", MONTHS_REQUEST);
+
+        final ReservationRequest reservationRequest = new ReservationRequest("바니",
+                LocalDateTime.of(NOW_PLUS_2_DAYS, SECOND_TIME),
+                FORM_ITEM_REQUESTS);
+        post("/api/reservations/coaches/" + COACH3.getId(), reservationRequest);
 
         // when
         final ExtractableResponse<Response> response = RestAssured.given().log().all()
-                .queryParam("year", AFTER_TWO_DAYS.getYear())
-                .queryParam("month", AFTER_TWO_DAYS.getMonthValue())
+                .queryParam("year", NOW_PLUS_2_DAYS.getYear())
+                .queryParam("month", NOW_PLUS_2_DAYS.getMonthValue())
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when().get("/api/coaches/" + COACH4.getId() + "/schedules")
+                .when().get("/api/coaches/" + COACH3.getId() + "/schedules")
                 .then().log().all()
                 .extract();
         final ScheduleResponse scheduleResponse = response.body().as(ScheduleResponse.class);
 
         // then
-        assertThat(scheduleResponse.getCalendar()).hasSize(4);
+        assertThat(scheduleResponse.getCalendar()).hasSize(1);
     }
 }

--- a/backend/src/test/java/com/woowacourse/ternoko/acceptance/MemberAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/ternoko/acceptance/MemberAcceptanceTest.java
@@ -2,6 +2,7 @@ package com.woowacourse.ternoko.acceptance;
 
 import static com.woowacourse.ternoko.fixture.CoachAvailableTimeFixture.FIRST_TIME;
 import static com.woowacourse.ternoko.fixture.CoachAvailableTimeFixture.MONTHS_REQUEST;
+import static com.woowacourse.ternoko.fixture.CoachAvailableTimeFixture.NOW;
 import static com.woowacourse.ternoko.fixture.CoachAvailableTimeFixture.NOW_PLUS_2_DAYS;
 import static com.woowacourse.ternoko.fixture.CoachAvailableTimeFixture.NOW_PLUS_3_DAYS;
 import static com.woowacourse.ternoko.fixture.CoachAvailableTimeFixture.NOW_PLUS_4_DAYS;
@@ -39,8 +40,8 @@ class MemberAcceptanceTest extends AcceptanceTest {
         // given
         put("/api/coaches/" + COACH3.getId() + "/calendar/times", MONTHS_REQUEST);
         final ExtractableResponse<Response> calendarResponse = get("/api/coaches/" + COACH3.getId()
-                + "/calendar/times?year=" + NOW_PLUS_2_DAYS.getYear()
-                + "&month=" + NOW_PLUS_2_DAYS.getMonthValue());
+                + "/calendar/times?year=" + NOW.getYear()
+                + "&month=" + NOW.getMonthValue());
 
         // when
         final AvailableDateTimesResponse response = calendarResponse.body().as(AvailableDateTimesResponse.class);
@@ -89,6 +90,5 @@ class MemberAcceptanceTest extends AcceptanceTest {
                         LocalDateTime.of(NOW_PLUS_4_DAYS, FIRST_TIME),
                         LocalDateTime.of(NOW_PLUS_4_DAYS, SECOND_TIME),
                         LocalDateTime.of(NOW_PLUS_4_DAYS, THIRD_TIME));
-
     }
 }

--- a/backend/src/test/java/com/woowacourse/ternoko/acceptance/MemberAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/ternoko/acceptance/MemberAcceptanceTest.java
@@ -1,26 +1,24 @@
 package com.woowacourse.ternoko.acceptance;
 
-import static com.woowacourse.ternoko.fixture.MemberFixture.AVAILABLE_DATE_TIME_REQUEST2;
-import static com.woowacourse.ternoko.fixture.MemberFixture.AVAILABLE_DATE_TIME_REQUEST3;
-import static com.woowacourse.ternoko.fixture.MemberFixture.AVAILABLE_DATE_TIME_REQUEST4;
-import static com.woowacourse.ternoko.fixture.MemberFixture.AVAILABLE_TIMES;
+import static com.woowacourse.ternoko.fixture.CoachAvailableTimeFixture.FIRST_TIME;
+import static com.woowacourse.ternoko.fixture.CoachAvailableTimeFixture.MONTHS_REQUEST;
+import static com.woowacourse.ternoko.fixture.CoachAvailableTimeFixture.NOW_PLUS_2_DAYS;
+import static com.woowacourse.ternoko.fixture.CoachAvailableTimeFixture.NOW_PLUS_3_DAYS;
+import static com.woowacourse.ternoko.fixture.CoachAvailableTimeFixture.NOW_PLUS_4_DAYS;
+import static com.woowacourse.ternoko.fixture.CoachAvailableTimeFixture.SECOND_TIME;
+import static com.woowacourse.ternoko.fixture.CoachAvailableTimeFixture.THIRD_TIME;
 import static com.woowacourse.ternoko.fixture.MemberFixture.COACH3;
-import static com.woowacourse.ternoko.fixture.MemberFixture.TIME2;
-import static com.woowacourse.ternoko.fixture.MemberFixture.TIME3;
-import static com.woowacourse.ternoko.fixture.MemberFixture.TIME4;
+import static com.woowacourse.ternoko.fixture.ReservationFixture.FORM_ITEM_REQUESTS;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.woowacourse.ternoko.dto.AvailableDateTimesResponse;
 import com.woowacourse.ternoko.dto.CoachesResponse;
-import com.woowacourse.ternoko.dto.request.AvailableDateTimeRequest;
-import com.woowacourse.ternoko.dto.request.AvailableDateTimesRequest;
+import com.woowacourse.ternoko.dto.request.ReservationRequest;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import java.time.LocalDateTime;
-import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.http.HttpStatus;
 
 class MemberAcceptanceTest extends AcceptanceTest {
 
@@ -36,74 +34,61 @@ class MemberAcceptanceTest extends AcceptanceTest {
     }
 
     @Test
-    @DisplayName("코치의 면담 가능 시간을 저장한다.")
-    void saveCalendarTimes() {
-        // given
-        final AvailableDateTimeRequest AVAILABLEDATETIMEREQUEST = new AvailableDateTimeRequest(
-                TIME2.getYear(),
-                TIME2.getMonthValue(),
-                AVAILABLE_TIMES);
-        final AvailableDateTimesRequest availableDateTimesRequest = new AvailableDateTimesRequest(List.of(
-                AVAILABLEDATETIMEREQUEST));
-
-        // when
-        final ExtractableResponse<Response> calendarResponse = put("/api/coaches/" + COACH3.getId() + "/calendar/times",
-                availableDateTimesRequest);
-
-        // then
-        assertThat(calendarResponse.statusCode()).isEqualTo(HttpStatus.OK.value());
-    }
-
-    @Test
-    @DisplayName("코치의 면담 가능 시간을 저장한다. - 여러 달")
-    void saveCalendarsTimes() {
-        // given
-        final AvailableDateTimesRequest availableDateTimesRequest = new AvailableDateTimesRequest(List.of(
-                AVAILABLE_DATE_TIME_REQUEST2,
-                AVAILABLE_DATE_TIME_REQUEST3,
-                AVAILABLE_DATE_TIME_REQUEST4));
-
-        // when
-        final ExtractableResponse<Response> calendarResponse = put("/api/coaches/" + COACH3.getId() + "/calendar/times",
-                availableDateTimesRequest);
-
-        // then
-        assertThat(calendarResponse.statusCode()).isEqualTo(HttpStatus.OK.value());
-    }
-
-    @Test
     @DisplayName("코치의 면담 가능 시간을 조회한다.")
     void findCalendarTimes() {
         // given
-        //TODO: Fixture 리팩토링 후 수정
-        final AvailableDateTimesRequest availableDateTimesRequest = new AvailableDateTimesRequest(List.of(
-                new AvailableDateTimeRequest(
-                        TIME2.getYear(),
-                        TIME2.getMonthValue(),
-                        List.of(
-                                LocalDateTime.of(TIME4.getYear(), TIME4.getMonthValue(),
-                                        TIME4.getDayOfMonth(), TIME4.getHour(), TIME4.getMinute()),
-                                LocalDateTime.of(TIME3.getYear(), TIME3.getMonthValue(),
-                                        TIME3.getDayOfMonth(), TIME3.getHour(), TIME3.getMinute()),
-                                LocalDateTime.of(TIME2.getYear(), TIME4.getMonthValue(),
-                                        TIME2.getDayOfMonth(), TIME2.getHour(), TIME2.getMinute())))));
-        put("/api/coaches/" + COACH3.getId() + "/calendar/times", availableDateTimesRequest);
-
-        final ExtractableResponse<Response> calendarResponse = get(
-                "/api/coaches/" + COACH3.getId() + "/calendar/times?year=2022&month=7");
+        put("/api/coaches/" + COACH3.getId() + "/calendar/times", MONTHS_REQUEST);
+        final ExtractableResponse<Response> calendarResponse = get("/api/coaches/" + COACH3.getId()
+                + "/calendar/times?year=" + NOW_PLUS_2_DAYS.getYear()
+                + "&month=" + NOW_PLUS_2_DAYS.getMonthValue());
 
         // when
         final AvailableDateTimesResponse response = calendarResponse.body().as(AvailableDateTimesResponse.class);
 
         // then
         assertThat(response.getCalendarTimes())
-                .hasSize(3)
-                .containsExactly(LocalDateTime.of(TIME2.getYear(), TIME2.getMonthValue(),
-                        TIME2.getDayOfMonth(), TIME2.getHour(), TIME2.getMinute()),
-                        LocalDateTime.of(TIME3.getYear(), TIME3.getMonthValue(),
-                                TIME3.getDayOfMonth(), TIME3.getHour(), TIME3.getMinute()),
-                        LocalDateTime.of(TIME4.getYear(), TIME4.getMonthValue(),
-                                TIME4.getDayOfMonth(), TIME4.getHour(), TIME4.getMinute())
-                );
+                .hasSize(9)
+                .containsExactly(LocalDateTime.of(NOW_PLUS_2_DAYS, FIRST_TIME),
+                        LocalDateTime.of(NOW_PLUS_2_DAYS, SECOND_TIME),
+                        LocalDateTime.of(NOW_PLUS_2_DAYS, THIRD_TIME),
+                        LocalDateTime.of(NOW_PLUS_3_DAYS, FIRST_TIME),
+                        LocalDateTime.of(NOW_PLUS_3_DAYS, SECOND_TIME),
+                        LocalDateTime.of(NOW_PLUS_3_DAYS, THIRD_TIME),
+                        LocalDateTime.of(NOW_PLUS_4_DAYS, FIRST_TIME),
+                        LocalDateTime.of(NOW_PLUS_4_DAYS, SECOND_TIME),
+                        LocalDateTime.of(NOW_PLUS_4_DAYS, THIRD_TIME));
+
+    }
+
+    @Test
+    @DisplayName("코치와 면담을 예약하면 해당 시간은 코치의 면담 가능 시간 목록에서 삭제된다.")
+    void findCalendarTimes_WhenCreateReservation_ThenExcludeDateTime() {
+        // given
+        put("/api/coaches/" + COACH3.getId() + "/calendar/times", MONTHS_REQUEST);
+
+        final ReservationRequest reservationRequest = new ReservationRequest("바니",
+                LocalDateTime.of(NOW_PLUS_2_DAYS, SECOND_TIME),
+                FORM_ITEM_REQUESTS);
+        post("/api/reservations/coaches/" + COACH3.getId(), reservationRequest);
+
+        final ExtractableResponse<Response> calendarResponse = get("/api/coaches/" + COACH3.getId()
+                + "/calendar/times?year=" + NOW_PLUS_2_DAYS.getYear()
+                + "&month=" + NOW_PLUS_2_DAYS.getMonthValue());
+
+        // when
+        final AvailableDateTimesResponse response = calendarResponse.body().as(AvailableDateTimesResponse.class);
+
+        // then
+        assertThat(response.getCalendarTimes())
+                .hasSize(8)
+                .containsExactly(LocalDateTime.of(NOW_PLUS_2_DAYS, FIRST_TIME),
+                        LocalDateTime.of(NOW_PLUS_2_DAYS, THIRD_TIME),
+                        LocalDateTime.of(NOW_PLUS_3_DAYS, FIRST_TIME),
+                        LocalDateTime.of(NOW_PLUS_3_DAYS, SECOND_TIME),
+                        LocalDateTime.of(NOW_PLUS_3_DAYS, THIRD_TIME),
+                        LocalDateTime.of(NOW_PLUS_4_DAYS, FIRST_TIME),
+                        LocalDateTime.of(NOW_PLUS_4_DAYS, SECOND_TIME),
+                        LocalDateTime.of(NOW_PLUS_4_DAYS, THIRD_TIME));
+
     }
 }

--- a/backend/src/test/java/com/woowacourse/ternoko/acceptance/ReservationAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/ternoko/acceptance/ReservationAcceptanceTest.java
@@ -1,17 +1,16 @@
 package com.woowacourse.ternoko.acceptance;
 
+import static com.woowacourse.ternoko.fixture.CoachAvailableTimeFixture.FIRST_TIME;
+import static com.woowacourse.ternoko.fixture.CoachAvailableTimeFixture.NOW_PLUS_2_DAYS;
 import static com.woowacourse.ternoko.fixture.MemberFixture.COACH1;
 import static com.woowacourse.ternoko.fixture.MemberFixture.COACH2;
 import static com.woowacourse.ternoko.fixture.MemberFixture.COACH3;
 import static com.woowacourse.ternoko.fixture.MemberFixture.COACH4;
-import static com.woowacourse.ternoko.fixture.ReservationFixture.AFTER_TWO_DAYS;
-import static com.woowacourse.ternoko.fixture.ReservationFixture.FORM_ITEM_REQUESTS;
 import static com.woowacourse.ternoko.fixture.ReservationFixture.INTERVIEW_TIME;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.woowacourse.ternoko.dto.ReservationResponse;
-import com.woowacourse.ternoko.dto.request.ReservationRequest;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import java.time.LocalDateTime;
@@ -26,7 +25,9 @@ class ReservationAcceptanceTest extends AcceptanceTest {
     @DisplayName("면담 예약을 생성한다.")
     void create() {
         // given, when
-        final ExtractableResponse<Response> response = createReservation(COACH1.getId(), "애쉬");
+        final ExtractableResponse<Response> response = createReservation(COACH1.getId(),
+                "애쉬",
+                LocalDateTime.of(NOW_PLUS_2_DAYS, FIRST_TIME));
 
         //then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
@@ -37,26 +38,22 @@ class ReservationAcceptanceTest extends AcceptanceTest {
     @DisplayName("면담 예약 상세 내역을 조회한다.")
     void findReservationById() {
         // given
-        final ReservationRequest reservationRequest = new ReservationRequest("수달7",
-                AFTER_TWO_DAYS,
-                FORM_ITEM_REQUESTS);
-
-        final ExtractableResponse<Response> createdResponse = post("/api/reservations/coaches/" + COACH3.getId(),
-                reservationRequest);
+        final ExtractableResponse<Response> createdResponse = createReservation(COACH1.getId(),
+                "수달",
+                LocalDateTime.of(NOW_PLUS_2_DAYS, FIRST_TIME));
 
         // when
         final ExtractableResponse<Response> response = get(createdResponse.header("Location"));
         final ReservationResponse reservationResponse = response.body().as(ReservationResponse.class);
-        final LocalDateTime reservationDatetime = reservationRequest.getInterviewDatetime();
 
         // then
         assertAll(
                 () -> assertThat(reservationResponse.getCoachNickname())
-                        .isEqualTo(COACH3.getNickname()),
+                        .isEqualTo(COACH1.getNickname()),
                 () -> assertThat(reservationResponse.getInterviewStartTime())
-                        .isEqualTo(reservationDatetime),
+                        .isEqualTo(LocalDateTime.of(NOW_PLUS_2_DAYS, FIRST_TIME)),
                 () -> assertThat(reservationResponse.getInterviewEndTime())
-                        .isEqualTo(reservationDatetime.plusMinutes(INTERVIEW_TIME))
+                        .isEqualTo(LocalDateTime.of(NOW_PLUS_2_DAYS, FIRST_TIME).plusMinutes(INTERVIEW_TIME))
         );
     }
 
@@ -64,10 +61,10 @@ class ReservationAcceptanceTest extends AcceptanceTest {
     @DisplayName("면담 예약 내역 목록을 조회한다.")
     void findAll() {
         // given
-        createReservation(COACH1.getId(), "애쉬");
-        createReservation(COACH2.getId(), "바니");
-        createReservation(COACH3.getId(), "앤지");
-        createReservation(COACH4.getId(), "열음");
+        createReservation(COACH1.getId(), "애쉬", LocalDateTime.of(NOW_PLUS_2_DAYS, FIRST_TIME));
+        createReservation(COACH2.getId(), "바니", LocalDateTime.of(NOW_PLUS_2_DAYS, FIRST_TIME));
+        createReservation(COACH3.getId(), "앤지", LocalDateTime.of(NOW_PLUS_2_DAYS, FIRST_TIME));
+        createReservation(COACH4.getId(), "열음", LocalDateTime.of(NOW_PLUS_2_DAYS, FIRST_TIME));
 
         // when
         final ExtractableResponse<Response> response = get("/api/reservations");

--- a/backend/src/test/java/com/woowacourse/ternoko/acceptance/ReservationAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/ternoko/acceptance/ReservationAcceptanceTest.java
@@ -1,6 +1,7 @@
 package com.woowacourse.ternoko.acceptance;
 
 import static com.woowacourse.ternoko.fixture.CoachAvailableTimeFixture.FIRST_TIME;
+import static com.woowacourse.ternoko.fixture.CoachAvailableTimeFixture.MONTHS_REQUEST;
 import static com.woowacourse.ternoko.fixture.CoachAvailableTimeFixture.NOW_PLUS_2_DAYS;
 import static com.woowacourse.ternoko.fixture.MemberFixture.COACH1;
 import static com.woowacourse.ternoko.fixture.MemberFixture.COACH2;
@@ -24,8 +25,10 @@ class ReservationAcceptanceTest extends AcceptanceTest {
     @Test
     @DisplayName("면담 예약을 생성한다.")
     void create() {
-        // given, when
-        final ExtractableResponse<Response> response = createReservation(COACH1.getId(),
+        // given
+        put("/api/coaches/" + COACH3.getId() + "/calendar/times", MONTHS_REQUEST);
+        // when
+        final ExtractableResponse<Response> response = createReservation(COACH3.getId(),
                 "애쉬",
                 LocalDateTime.of(NOW_PLUS_2_DAYS, FIRST_TIME));
 
@@ -35,10 +38,24 @@ class ReservationAcceptanceTest extends AcceptanceTest {
     }
 
     @Test
+    @DisplayName("선택한 일시가 코치의 가능한 시간이 아니라면 면담을 생성할 때 예외가 발생한다.")
+    void create_WhenInvalidAvailableDateTime() {
+        // given
+        // when
+        final ExtractableResponse<Response> response = createReservation(COACH3.getId(),
+                "애쉬",
+                LocalDateTime.of(NOW_PLUS_2_DAYS, FIRST_TIME));
+
+        //then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+    }
+
+    @Test
     @DisplayName("면담 예약 상세 내역을 조회한다.")
     void findReservationById() {
         // given
-        final ExtractableResponse<Response> createdResponse = createReservation(COACH1.getId(),
+        put("/api/coaches/" + COACH3.getId() + "/calendar/times", MONTHS_REQUEST);
+        final ExtractableResponse<Response> createdResponse = createReservation(COACH3.getId(),
                 "수달",
                 LocalDateTime.of(NOW_PLUS_2_DAYS, FIRST_TIME));
 
@@ -49,7 +66,7 @@ class ReservationAcceptanceTest extends AcceptanceTest {
         // then
         assertAll(
                 () -> assertThat(reservationResponse.getCoachNickname())
-                        .isEqualTo(COACH1.getNickname()),
+                        .isEqualTo(COACH3.getNickname()),
                 () -> assertThat(reservationResponse.getInterviewStartTime())
                         .isEqualTo(LocalDateTime.of(NOW_PLUS_2_DAYS, FIRST_TIME)),
                 () -> assertThat(reservationResponse.getInterviewEndTime())
@@ -61,6 +78,11 @@ class ReservationAcceptanceTest extends AcceptanceTest {
     @DisplayName("면담 예약 내역 목록을 조회한다.")
     void findAll() {
         // given
+        put("/api/coaches/" + COACH1.getId() + "/calendar/times", MONTHS_REQUEST);
+        put("/api/coaches/" + COACH2.getId() + "/calendar/times", MONTHS_REQUEST);
+        put("/api/coaches/" + COACH3.getId() + "/calendar/times", MONTHS_REQUEST);
+        put("/api/coaches/" + COACH4.getId() + "/calendar/times", MONTHS_REQUEST);
+
         createReservation(COACH1.getId(), "애쉬", LocalDateTime.of(NOW_PLUS_2_DAYS, FIRST_TIME));
         createReservation(COACH2.getId(), "바니", LocalDateTime.of(NOW_PLUS_2_DAYS, FIRST_TIME));
         createReservation(COACH3.getId(), "앤지", LocalDateTime.of(NOW_PLUS_2_DAYS, FIRST_TIME));

--- a/backend/src/test/java/com/woowacourse/ternoko/fixture/CoachAvailableTimeFixture.java
+++ b/backend/src/test/java/com/woowacourse/ternoko/fixture/CoachAvailableTimeFixture.java
@@ -9,6 +9,7 @@ import java.util.List;
 
 public class CoachAvailableTimeFixture {
 
+    public static final LocalDate NOW = LocalDate.now();
     public static final LocalDate NOW_PLUS_2_DAYS = LocalDate.now().plusDays(2);
     public static final LocalDate NOW_PLUS_3_DAYS = LocalDate.now().plusDays(3);
     public static final LocalDate NOW_PLUS_4_DAYS = LocalDate.now().plusDays(4);

--- a/backend/src/test/java/com/woowacourse/ternoko/fixture/CoachAvailableTimeFixture.java
+++ b/backend/src/test/java/com/woowacourse/ternoko/fixture/CoachAvailableTimeFixture.java
@@ -12,6 +12,8 @@ public class CoachAvailableTimeFixture {
     public static final LocalDate NOW = LocalDate.
             now().plusDays(4).getMonthValue() > LocalDate.now().getMonthValue() ?
             LocalDate.now().plusDays(4) : LocalDate.now();
+
+    public static final LocalDate NOW_MINUS_2_DAYS = NOW.minusDays(2);
     public static final LocalDate NOW_PLUS_2_DAYS = NOW.plusDays(2);
     public static final LocalDate NOW_PLUS_3_DAYS = NOW.plusDays(3);
     public static final LocalDate NOW_PLUS_4_DAYS = NOW.plusDays(4);
@@ -21,6 +23,16 @@ public class CoachAvailableTimeFixture {
     public static final LocalTime FIRST_TIME = LocalTime.of(11, 0);
     public static final LocalTime SECOND_TIME = LocalTime.of(14, 0);
     public static final LocalTime THIRD_TIME = LocalTime.of(16, 0);
+
+    public static final AvailableDateTimeRequest PAST_TIME_RESPONSE = new AvailableDateTimeRequest(
+            NOW.getYear(),
+            NOW.getMonthValue(),
+            List.of(LocalDateTime.of(NOW_MINUS_2_DAYS, FIRST_TIME),
+                    LocalDateTime.of(NOW_MINUS_2_DAYS, SECOND_TIME),
+                    LocalDateTime.of(NOW_MINUS_2_DAYS, THIRD_TIME),
+                    LocalDateTime.of(NOW, FIRST_TIME),
+                    LocalDateTime.of(NOW, SECOND_TIME),
+                    LocalDateTime.of(NOW, THIRD_TIME)));
 
     public static final AvailableDateTimeRequest NOW_MONTH_REQUEST = new AvailableDateTimeRequest(
             NOW.getYear(),
@@ -42,20 +54,12 @@ public class CoachAvailableTimeFixture {
                     LocalDateTime.of(NOW_PLUS_1_MONTH, SECOND_TIME),
                     LocalDateTime.of(NOW_PLUS_1_MONTH, THIRD_TIME)));
 
+    public static final AvailableDateTimesRequest PAST_REQUEST = new AvailableDateTimesRequest(
+            List.of(NOW_MONTH_REQUEST));
+
     public static final AvailableDateTimesRequest MONTH_REQUEST = new AvailableDateTimesRequest(
             List.of(NOW_MONTH_REQUEST));
 
     public static final AvailableDateTimesRequest MONTHS_REQUEST = new AvailableDateTimesRequest(
             List.of(NOW_MONTH_REQUEST, NEXT_MONTH_REQUEST));
-
-    public static final List<LocalDateTime> COACH_AVAILABLE_TIME = List.of(
-            LocalDateTime.of(NOW_PLUS_2_DAYS, FIRST_TIME),
-            LocalDateTime.of(NOW_PLUS_2_DAYS, SECOND_TIME),
-            LocalDateTime.of(NOW_PLUS_2_DAYS, THIRD_TIME),
-            LocalDateTime.of(NOW_PLUS_3_DAYS, FIRST_TIME),
-            LocalDateTime.of(NOW_PLUS_3_DAYS, SECOND_TIME),
-            LocalDateTime.of(NOW_PLUS_3_DAYS, THIRD_TIME),
-            LocalDateTime.of(NOW_PLUS_4_DAYS, FIRST_TIME),
-            LocalDateTime.of(NOW_PLUS_4_DAYS, SECOND_TIME),
-            LocalDateTime.of(NOW_PLUS_4_DAYS, THIRD_TIME));
 }

--- a/backend/src/test/java/com/woowacourse/ternoko/fixture/CoachAvailableTimeFixture.java
+++ b/backend/src/test/java/com/woowacourse/ternoko/fixture/CoachAvailableTimeFixture.java
@@ -9,20 +9,22 @@ import java.util.List;
 
 public class CoachAvailableTimeFixture {
 
-    public static final LocalDate NOW = LocalDate.now();
-    public static final LocalDate NOW_PLUS_2_DAYS = LocalDate.now().plusDays(2);
-    public static final LocalDate NOW_PLUS_3_DAYS = LocalDate.now().plusDays(3);
-    public static final LocalDate NOW_PLUS_4_DAYS = LocalDate.now().plusDays(4);
+    public static final LocalDate NOW = LocalDate.
+            now().plusDays(4).getMonthValue() > LocalDate.now().getMonthValue() ?
+            LocalDate.now().plusDays(4) : LocalDate.now();
+    public static final LocalDate NOW_PLUS_2_DAYS = NOW.plusDays(2);
+    public static final LocalDate NOW_PLUS_3_DAYS = NOW.plusDays(3);
+    public static final LocalDate NOW_PLUS_4_DAYS = NOW.plusDays(4);
 
-    public static final LocalDate NOW_PLUS_1_MONTH = LocalDate.now().plusMonths(1);
+    public static final LocalDate NOW_PLUS_1_MONTH = NOW.plusMonths(1);
 
     public static final LocalTime FIRST_TIME = LocalTime.of(11, 0);
     public static final LocalTime SECOND_TIME = LocalTime.of(14, 0);
     public static final LocalTime THIRD_TIME = LocalTime.of(16, 0);
 
     public static final AvailableDateTimeRequest NOW_MONTH_REQUEST = new AvailableDateTimeRequest(
-            NOW_PLUS_2_DAYS.getYear(),
-            NOW_PLUS_2_DAYS.getMonthValue(),
+            NOW.getYear(),
+            NOW.getMonthValue(),
             List.of(LocalDateTime.of(NOW_PLUS_2_DAYS, FIRST_TIME),
                     LocalDateTime.of(NOW_PLUS_2_DAYS, SECOND_TIME),
                     LocalDateTime.of(NOW_PLUS_2_DAYS, THIRD_TIME),

--- a/backend/src/test/java/com/woowacourse/ternoko/fixture/CoachAvailableTimeFixture.java
+++ b/backend/src/test/java/com/woowacourse/ternoko/fixture/CoachAvailableTimeFixture.java
@@ -1,0 +1,58 @@
+package com.woowacourse.ternoko.fixture;
+
+import com.woowacourse.ternoko.dto.request.AvailableDateTimeRequest;
+import com.woowacourse.ternoko.dto.request.AvailableDateTimesRequest;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+
+public class CoachAvailableTimeFixture {
+
+    public static final LocalDate NOW_PLUS_2_DAYS = LocalDate.now().plusDays(2);
+    public static final LocalDate NOW_PLUS_3_DAYS = LocalDate.now().plusDays(3);
+    public static final LocalDate NOW_PLUS_4_DAYS = LocalDate.now().plusDays(4);
+
+    public static final LocalDate NOW_PLUS_1_MONTH = LocalDate.now().plusMonths(1);
+
+    public static final LocalTime FIRST_TIME = LocalTime.of(11, 0);
+    public static final LocalTime SECOND_TIME = LocalTime.of(14, 0);
+    public static final LocalTime THIRD_TIME = LocalTime.of(16, 0);
+
+    public static final AvailableDateTimeRequest NOW_MONTH_REQUEST = new AvailableDateTimeRequest(
+            NOW_PLUS_2_DAYS.getYear(),
+            NOW_PLUS_2_DAYS.getMonthValue(),
+            List.of(LocalDateTime.of(NOW_PLUS_2_DAYS, FIRST_TIME),
+                    LocalDateTime.of(NOW_PLUS_2_DAYS, SECOND_TIME),
+                    LocalDateTime.of(NOW_PLUS_2_DAYS, THIRD_TIME),
+                    LocalDateTime.of(NOW_PLUS_3_DAYS, FIRST_TIME),
+                    LocalDateTime.of(NOW_PLUS_3_DAYS, SECOND_TIME),
+                    LocalDateTime.of(NOW_PLUS_3_DAYS, THIRD_TIME),
+                    LocalDateTime.of(NOW_PLUS_4_DAYS, FIRST_TIME),
+                    LocalDateTime.of(NOW_PLUS_4_DAYS, SECOND_TIME),
+                    LocalDateTime.of(NOW_PLUS_4_DAYS, THIRD_TIME)));
+
+    public static final AvailableDateTimeRequest NEXT_MONTH_REQUEST = new AvailableDateTimeRequest(
+            NOW_PLUS_1_MONTH.getYear(),
+            NOW_PLUS_1_MONTH.getMonthValue(),
+            List.of(LocalDateTime.of(NOW_PLUS_1_MONTH, FIRST_TIME),
+                    LocalDateTime.of(NOW_PLUS_1_MONTH, SECOND_TIME),
+                    LocalDateTime.of(NOW_PLUS_1_MONTH, THIRD_TIME)));
+
+    public static final AvailableDateTimesRequest MONTH_REQUEST = new AvailableDateTimesRequest(
+            List.of(NOW_MONTH_REQUEST));
+
+    public static final AvailableDateTimesRequest MONTHS_REQUEST = new AvailableDateTimesRequest(
+            List.of(NOW_MONTH_REQUEST, NEXT_MONTH_REQUEST));
+
+    public static final List<LocalDateTime> COACH_AVAILABLE_TIME = List.of(
+            LocalDateTime.of(NOW_PLUS_2_DAYS, FIRST_TIME),
+            LocalDateTime.of(NOW_PLUS_2_DAYS, SECOND_TIME),
+            LocalDateTime.of(NOW_PLUS_2_DAYS, THIRD_TIME),
+            LocalDateTime.of(NOW_PLUS_3_DAYS, FIRST_TIME),
+            LocalDateTime.of(NOW_PLUS_3_DAYS, SECOND_TIME),
+            LocalDateTime.of(NOW_PLUS_3_DAYS, THIRD_TIME),
+            LocalDateTime.of(NOW_PLUS_4_DAYS, FIRST_TIME),
+            LocalDateTime.of(NOW_PLUS_4_DAYS, SECOND_TIME),
+            LocalDateTime.of(NOW_PLUS_4_DAYS, THIRD_TIME));
+}

--- a/backend/src/test/java/com/woowacourse/ternoko/service/CoachServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/ternoko/service/CoachServiceTest.java
@@ -1,24 +1,26 @@
 package com.woowacourse.ternoko.service;
 
-import static com.woowacourse.ternoko.fixture.MemberFixture.*;
-import static org.assertj.core.api.Assertions.*;
+import static com.woowacourse.ternoko.fixture.CoachAvailableTimeFixture.MONTHS_REQUEST;
+import static com.woowacourse.ternoko.fixture.CoachAvailableTimeFixture.MONTH_REQUEST;
+import static com.woowacourse.ternoko.fixture.CoachAvailableTimeFixture.NEXT_MONTH_REQUEST;
+import static com.woowacourse.ternoko.fixture.CoachAvailableTimeFixture.NOW;
+import static com.woowacourse.ternoko.fixture.CoachAvailableTimeFixture.NOW_PLUS_1_MONTH;
+import static com.woowacourse.ternoko.fixture.MemberFixture.COACH3;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import java.time.LocalDateTime;
+import com.woowacourse.ternoko.common.exception.CoachNotFoundException;
+import com.woowacourse.ternoko.domain.AvailableDateTime;
+import com.woowacourse.ternoko.dto.CoachesResponse;
+import com.woowacourse.ternoko.dto.request.AvailableDateTimesRequest;
 import java.util.List;
 import java.util.stream.Collectors;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.transaction.annotation.Transactional;
-
-import com.woowacourse.ternoko.common.exception.CoachNotFoundException;
-import com.woowacourse.ternoko.domain.AvailableDateTime;
-import com.woowacourse.ternoko.dto.CoachesResponse;
-import com.woowacourse.ternoko.dto.request.AvailableDateTimeRequest;
-import com.woowacourse.ternoko.dto.request.AvailableDateTimesRequest;
 
 @Transactional
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
@@ -42,21 +44,15 @@ public class CoachServiceTest {
     @DisplayName("코치의 면담 가능 시간을 저장한다.")
     void putAvailableDateTimesByCoachId() {
         // given
-        int year = TIME2.getYear();
-        int month = TIME2.getMonthValue();
-        final AvailableDateTimeRequest availableDateTimeRequest = new AvailableDateTimeRequest(
-            year,
-            month,
-            AVAILABLE_TIMES);
-
-        coachService.putAvailableDateTimesByCoachId(COACH3.getId(), new AvailableDateTimesRequest(List.of(availableDateTimeRequest)));
+        coachService.putAvailableDateTimesByCoachId(COACH3.getId(), MONTH_REQUEST);
 
         // whenR
-        final List<AvailableDateTime> availableDateTimes = coachService
-            .findAvailableDateTimesByCoachId(COACH3.getId(), year, month);
+        final List<AvailableDateTime> availableDateTimes = coachService.findAvailableDateTimesByCoachId(COACH3.getId(),
+                NOW.getYear(),
+                NOW.getMonthValue());
 
         // then
-        assertThat(availableDateTimes).hasSize(3);
+        assertThat(availableDateTimes).hasSize(9);
     }
 
     @Test
@@ -67,7 +63,7 @@ public class CoachServiceTest {
 
         // when
         final List<AvailableDateTime> availableDateTimes = coachService
-            .findAvailableDateTimesByCoachId(COACH3.getId(), TIME2.getYear(), TIME2.getMonthValue());
+                .findAvailableDateTimesByCoachId(COACH3.getId(), NOW.getYear(), NOW.getMonthValue());
 
         // then
         assertThat(availableDateTimes).hasSize(0);
@@ -77,38 +73,26 @@ public class CoachServiceTest {
     @DisplayName("코치의 면담 가능 시간 저장시 존재하지 않는 코치 id를 넣어줄 경우 예외가 발생한다.")
     void putAvailableDateTimesByInvalidCoachId() {
         assertThatThrownBy(
-                () -> coachService.putAvailableDateTimesByCoachId(-1L, new AvailableDateTimesRequest(List.of())))
-                .isInstanceOf(CoachNotFoundException.class);
+                () -> coachService.putAvailableDateTimesByCoachId(-1L, new AvailableDateTimesRequest(List.of()))
+        ).isInstanceOf(CoachNotFoundException.class);
     }
 
     @Test
     @DisplayName("코치의 면담 가능 시간을 조회한다.")
     void findAvailableDateTimesByCoachId() {
         // given
-        final List<LocalDateTime> times = AVAILABLE_TIMES;
-        final AvailableDateTimeRequest availableDateTimeRequest = new AvailableDateTimeRequest(
-            TIME2.getYear(),
-            TIME2.getMonthValue(),
-            times);
-        final LocalDateTime nextMonthDatTime = LocalDateTime.now().plusMonths(1);
-        final AvailableDateTimeRequest nextMonthAvailableDateTimeRequest = new AvailableDateTimeRequest(
-            nextMonthDatTime.getYear(),
-            nextMonthDatTime.getMonthValue(),
-            List.of(nextMonthDatTime));
-
-        coachService.putAvailableDateTimesByCoachId(COACH3.getId(), new AvailableDateTimesRequest(
-            List.of(availableDateTimeRequest,
-                nextMonthAvailableDateTimeRequest)));
+        coachService.putAvailableDateTimesByCoachId(COACH3.getId(), MONTHS_REQUEST);
 
         // when
-        final List<AvailableDateTime> availableDateTimes = coachService
-            .findAvailableDateTimesByCoachId(COACH3.getId(), TIME2.getYear(), TIME2.getMonthValue());
+        final List<AvailableDateTime> availableDateTimes = coachService.findAvailableDateTimesByCoachId(COACH3.getId(),
+                NOW_PLUS_1_MONTH.getYear(),
+                NOW_PLUS_1_MONTH.getMonthValue());
 
         // then
         assertThat(availableDateTimes.stream()
                 .map(AvailableDateTime::getLocalDateTime)
                 .collect(Collectors.toList()))
-                .hasSize(times.size())
-                .containsAnyElementsOf(times);
+                .hasSize(NEXT_MONTH_REQUEST.getTimes().size())
+                .containsAnyElementsOf(NEXT_MONTH_REQUEST.getTimes());
     }
 }

--- a/backend/src/test/java/com/woowacourse/ternoko/service/ReservationServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/ternoko/service/ReservationServiceTest.java
@@ -1,15 +1,17 @@
 package com.woowacourse.ternoko.service;
 
+import static com.woowacourse.ternoko.fixture.CoachAvailableTimeFixture.FIRST_TIME;
+import static com.woowacourse.ternoko.fixture.CoachAvailableTimeFixture.MONTH_REQUEST;
+import static com.woowacourse.ternoko.fixture.CoachAvailableTimeFixture.NOW;
+import static com.woowacourse.ternoko.fixture.CoachAvailableTimeFixture.NOW_PLUS_2_DAYS;
+import static com.woowacourse.ternoko.fixture.CoachAvailableTimeFixture.NOW_PLUS_3_DAYS;
+import static com.woowacourse.ternoko.fixture.CoachAvailableTimeFixture.SECOND_TIME;
 import static com.woowacourse.ternoko.fixture.MemberFixture.COACH1;
 import static com.woowacourse.ternoko.fixture.MemberFixture.COACH2;
 import static com.woowacourse.ternoko.fixture.MemberFixture.COACH3;
 import static com.woowacourse.ternoko.fixture.MemberFixture.COACH4;
 import static com.woowacourse.ternoko.fixture.ReservationFixture.FORM_ITEM_REQUESTS;
 import static com.woowacourse.ternoko.fixture.ReservationFixture.INTERVIEW_TIME;
-import static com.woowacourse.ternoko.fixture.ReservationFixture.RESERVATION_REQUEST1;
-import static com.woowacourse.ternoko.fixture.ReservationFixture.RESERVATION_REQUEST2;
-import static com.woowacourse.ternoko.fixture.ReservationFixture.RESERVATION_REQUEST3;
-import static com.woowacourse.ternoko.fixture.ReservationFixture.RESERVATION_REQUEST4;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -37,23 +39,30 @@ class ReservationServiceTest {
     @Autowired
     private ReservationService reservationService;
 
+    @Autowired
+    private CoachService coachService;
+
     @Test
     @DisplayName("면담 예약을 생성한다.")
     void create() {
         // given, when
-        final Long id = reservationService.create(COACH1.getId(), RESERVATION_REQUEST3);
+        coachService.putAvailableDateTimesByCoachId(COACH3.getId(), MONTH_REQUEST);
+
+        final Long id = reservationService.create(COACH3.getId(), new ReservationRequest("앤지",
+                LocalDateTime.of(NOW_PLUS_2_DAYS, FIRST_TIME),
+                FORM_ITEM_REQUESTS));
+
         final ReservationResponse reservationResponse = reservationService.findReservationById(id);
-        final LocalDateTime reservationDatetime = RESERVATION_REQUEST3.getInterviewDatetime();
 
         // then
         assertAll(
                 () -> assertThat(id).isNotNull(),
                 () -> assertThat(reservationResponse.getCoachNickname())
-                        .isEqualTo(COACH1.getNickname()),
+                        .isEqualTo(COACH3.getNickname()),
                 () -> assertThat(reservationResponse.getInterviewStartTime())
-                        .isEqualTo(reservationDatetime),
+                        .isEqualTo(LocalDateTime.of(NOW_PLUS_2_DAYS, FIRST_TIME)),
                 () -> assertThat(reservationResponse.getInterviewEndTime())
-                        .isEqualTo(reservationDatetime.plusMinutes(INTERVIEW_TIME)),
+                        .isEqualTo(LocalDateTime.of(NOW_PLUS_2_DAYS, FIRST_TIME).plusMinutes(INTERVIEW_TIME)),
                 () -> assertThat(reservationResponse.getInterviewQuestions())
                         .extracting("question")
                         .contains("고정질문1", "고정질문2", "고정질문3"),
@@ -64,9 +73,21 @@ class ReservationServiceTest {
     }
 
     @Test
+    @DisplayName("면담 예약 선택 일자가 코치의 가능한 시간이 아닌 경우 예외가 발생한다.")
+    void create_WhenInvalidAvailableDateTime() {
+        assertThatThrownBy(() -> reservationService.create(COACH1.getId(), new ReservationRequest("앤지",
+                LocalDateTime.of(NOW_PLUS_2_DAYS, FIRST_TIME),
+                FORM_ITEM_REQUESTS)))
+                .isInstanceOf(InvalidReservationDateException.class)
+                .hasMessage(ExceptionType.INVALID_AVAILABLE_DATE_TIME.getMessage());
+    }
+
+    @Test
     @DisplayName("없는 코치로 예약할 시 예외가 발생한다.")
     void create_coachNotFound() {
-        assertThatThrownBy(() -> reservationService.create(-1L, RESERVATION_REQUEST3))
+        assertThatThrownBy(() -> reservationService.create(-1L, new ReservationRequest("앤지",
+                LocalDateTime.of(NOW_PLUS_2_DAYS, FIRST_TIME),
+                FORM_ITEM_REQUESTS)))
                 .isInstanceOf(CoachNotFoundException.class);
     }
 
@@ -81,10 +102,18 @@ class ReservationServiceTest {
     @DisplayName("면담 예약 목록을 조회한다.")
     void findAllReservations() {
         // given
-        reservationService.create(COACH1.getId(), RESERVATION_REQUEST1);
-        reservationService.create(COACH2.getId(), RESERVATION_REQUEST2);
-        reservationService.create(COACH3.getId(), RESERVATION_REQUEST3);
-        reservationService.create(COACH4.getId(), RESERVATION_REQUEST4);
+        coachService.putAvailableDateTimesByCoachId(COACH1.getId(), MONTH_REQUEST);
+        coachService.putAvailableDateTimesByCoachId(COACH2.getId(), MONTH_REQUEST);
+        coachService.putAvailableDateTimesByCoachId(COACH3.getId(), MONTH_REQUEST);
+        coachService.putAvailableDateTimesByCoachId(COACH4.getId(), MONTH_REQUEST);
+        reservationService.create(COACH1.getId(),
+                new ReservationRequest("바니", LocalDateTime.of(NOW_PLUS_2_DAYS, FIRST_TIME), FORM_ITEM_REQUESTS));
+        reservationService.create(COACH2.getId(),
+                new ReservationRequest("열음", LocalDateTime.of(NOW_PLUS_2_DAYS, SECOND_TIME), FORM_ITEM_REQUESTS));
+        reservationService.create(COACH3.getId(),
+                new ReservationRequest("앤지", LocalDateTime.of(NOW_PLUS_3_DAYS, FIRST_TIME), FORM_ITEM_REQUESTS));
+        reservationService.create(COACH4.getId(),
+                new ReservationRequest("애쉬", LocalDateTime.of(NOW_PLUS_3_DAYS, SECOND_TIME), FORM_ITEM_REQUESTS));
 
         // when
         final List<ReservationResponse> reservationResponses = reservationService.findAllReservations();
@@ -99,13 +128,20 @@ class ReservationServiceTest {
     @DisplayName("코치별로 면담예약 목록을 조회한다.")
     void findAllByCoach() {
         // given
-        reservationService.create(COACH4.getId(), RESERVATION_REQUEST1);
-        reservationService.create(COACH4.getId(), RESERVATION_REQUEST2);
-        reservationService.create(COACH4.getId(), RESERVATION_REQUEST3);
-        reservationService.create(COACH4.getId(), RESERVATION_REQUEST4);
+        coachService.putAvailableDateTimesByCoachId(COACH4.getId(), MONTH_REQUEST);
+        reservationService.create(COACH4.getId(),
+                new ReservationRequest("바니", LocalDateTime.of(NOW_PLUS_2_DAYS, FIRST_TIME), FORM_ITEM_REQUESTS));
+        reservationService.create(COACH4.getId(),
+                new ReservationRequest("열음", LocalDateTime.of(NOW_PLUS_2_DAYS, SECOND_TIME), FORM_ITEM_REQUESTS));
+        reservationService.create(COACH4.getId(),
+                new ReservationRequest("앤지", LocalDateTime.of(NOW_PLUS_3_DAYS, FIRST_TIME), FORM_ITEM_REQUESTS));
+        reservationService.create(COACH4.getId(),
+                new ReservationRequest("애쉬", LocalDateTime.of(NOW_PLUS_3_DAYS, SECOND_TIME), FORM_ITEM_REQUESTS));
 
         // when
-        final ScheduleResponse scheduleResponses = reservationService.findAllByCoach(COACH4.getId(), 2022, 7);
+        final ScheduleResponse scheduleResponses = reservationService.findAllByCoach(COACH4.getId(),
+                NOW.getYear(),
+                NOW.getMonthValue());
 
         // then
         assertThat(scheduleResponses.getCalendar()).extracting("crewNickname")
@@ -116,8 +152,8 @@ class ReservationServiceTest {
     @Test
     @DisplayName("면담 예약시, 당일 예약을 시도하면 에러가 발생한다.")
     void createReservationTodayException() {
-        final ReservationRequest request = new ReservationRequest("SUDAL", LocalDateTime.now(), FORM_ITEM_REQUESTS);
-        assertThatThrownBy(() -> reservationService.create(COACH2.getId(), request))
+        assertThatThrownBy(() -> reservationService.create(COACH2.getId(),
+                new ReservationRequest("SUDAL", LocalDateTime.now(), FORM_ITEM_REQUESTS)))
                 .isInstanceOf(InvalidReservationDateException.class)
                 .hasMessage(ExceptionType.INVALID_RESERVATION_DATE.getMessage());
     }
@@ -125,9 +161,8 @@ class ReservationServiceTest {
     @Test
     @DisplayName("면담 예약시, 과거 기간 예약을 시도하면 에러가 발생한다.")
     void createReservationException() {
-        final ReservationRequest request = new ReservationRequest("SUDAL", LocalDateTime.now().minusDays(1),
-                FORM_ITEM_REQUESTS);
-        assertThatThrownBy(() -> reservationService.create(COACH2.getId(), request))
+        assertThatThrownBy(() -> reservationService.create(COACH2.getId(),
+                new ReservationRequest("SUDAL", LocalDateTime.now().minusDays(1), FORM_ITEM_REQUESTS)))
                 .isInstanceOf(InvalidReservationDateException.class)
                 .hasMessage(ExceptionType.INVALID_RESERVATION_DATE.getMessage());
     }

--- a/backend/src/test/java/com/woowacourse/ternoko/service/ReservationServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/ternoko/service/ReservationServiceTest.java
@@ -3,9 +3,13 @@ package com.woowacourse.ternoko.service;
 import static com.woowacourse.ternoko.fixture.CoachAvailableTimeFixture.FIRST_TIME;
 import static com.woowacourse.ternoko.fixture.CoachAvailableTimeFixture.MONTH_REQUEST;
 import static com.woowacourse.ternoko.fixture.CoachAvailableTimeFixture.NOW;
+import static com.woowacourse.ternoko.fixture.CoachAvailableTimeFixture.NOW_MINUS_2_DAYS;
 import static com.woowacourse.ternoko.fixture.CoachAvailableTimeFixture.NOW_PLUS_2_DAYS;
 import static com.woowacourse.ternoko.fixture.CoachAvailableTimeFixture.NOW_PLUS_3_DAYS;
+import static com.woowacourse.ternoko.fixture.CoachAvailableTimeFixture.PAST_REQUEST;
+import static com.woowacourse.ternoko.fixture.CoachAvailableTimeFixture.PAST_TIME_RESPONSE;
 import static com.woowacourse.ternoko.fixture.CoachAvailableTimeFixture.SECOND_TIME;
+import static com.woowacourse.ternoko.fixture.CoachAvailableTimeFixture.THIRD_TIME;
 import static com.woowacourse.ternoko.fixture.MemberFixture.COACH1;
 import static com.woowacourse.ternoko.fixture.MemberFixture.COACH2;
 import static com.woowacourse.ternoko.fixture.MemberFixture.COACH3;
@@ -22,8 +26,12 @@ import com.woowacourse.ternoko.common.exception.InvalidReservationDateException;
 import com.woowacourse.ternoko.common.exception.ReservationNotFoundException;
 import com.woowacourse.ternoko.dto.ReservationResponse;
 import com.woowacourse.ternoko.dto.ScheduleResponse;
+import com.woowacourse.ternoko.dto.request.AvailableDateTimeRequest;
+import com.woowacourse.ternoko.dto.request.AvailableDateTimesRequest;
 import com.woowacourse.ternoko.dto.request.ReservationRequest;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -152,8 +160,12 @@ class ReservationServiceTest {
     @Test
     @DisplayName("면담 예약시, 당일 예약을 시도하면 에러가 발생한다.")
     void createReservationTodayException() {
-        assertThatThrownBy(() -> reservationService.create(COACH2.getId(),
-                new ReservationRequest("SUDAL", LocalDateTime.now(), FORM_ITEM_REQUESTS)))
+        // given
+        coachService.putAvailableDateTimesByCoachId(COACH4.getId(), PAST_REQUEST);
+
+        // when & then
+        assertThatThrownBy(() -> reservationService.create(COACH4.getId(),
+                new ReservationRequest("SUDAL", LocalDateTime.of(NOW, THIRD_TIME), FORM_ITEM_REQUESTS)))
                 .isInstanceOf(InvalidReservationDateException.class)
                 .hasMessage(ExceptionType.INVALID_RESERVATION_DATE.getMessage());
     }
@@ -161,8 +173,12 @@ class ReservationServiceTest {
     @Test
     @DisplayName("면담 예약시, 과거 기간 예약을 시도하면 에러가 발생한다.")
     void createReservationException() {
-        assertThatThrownBy(() -> reservationService.create(COACH2.getId(),
-                new ReservationRequest("SUDAL", LocalDateTime.now().minusDays(1), FORM_ITEM_REQUESTS)))
+        // given
+        coachService.putAvailableDateTimesByCoachId(COACH4.getId(), PAST_REQUEST);
+
+        // when & then
+        assertThatThrownBy(() -> reservationService.create(COACH4.getId(),
+                new ReservationRequest("SUDAL", LocalDateTime.of(NOW_MINUS_2_DAYS, THIRD_TIME), FORM_ITEM_REQUESTS)))
                 .isInstanceOf(InvalidReservationDateException.class)
                 .hasMessage(ExceptionType.INVALID_RESERVATION_DATE.getMessage());
     }


### PR DESCRIPTION
### Issues
- [x] #80 
- [ ] #87 

### 논의사항
- 예약 생성 시 AvailableTime을 삭제하도록 수정하였습니다.
- 추후 면담 취소 기능을 구현할 때  AvailableTime을 다시 저장하는 기능 구현이 필요해보입니다. (**중요**)
- 테스트 코드 작성하려고 했는데 현재 AvailableTime 관련 Fixture의 리팩터링이 필요해보이고 그 이후에 작성하는게 좋을 것 같습니다.
    - [ ] AvailableTime Fixture 리팩터링
    - [ ] 회원 기능을 추가하여 Coach, Crew의 Acceptance Test 분리 

### 동작 테스트
- 기존 테스트 코드 실행 결과 : 정상 동작
- Application 실행 후 테스트 : 정상 동작

close #80 
close #87



