### PR TITLE
[BE] feat: 예약 수정 및 삭제 기능 구현 및 슬랙 알람 기능 도입

### DIFF
--- a/backend/src/main/java/com/woowacourse/ternoko/common/exception/ExceptionType.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/common/exception/ExceptionType.java
@@ -11,6 +11,7 @@ public enum ExceptionType {
     COACH_NOT_FOUND(HttpStatus.BAD_REQUEST, "번째 코치를 찾을 수 없습니다."),
     CREW_NOT_FOUND(HttpStatus.BAD_REQUEST, "번째 크루를 찾을 수 없습니다."),
     RESERVATION_NOT_FOUND(HttpStatus.BAD_REQUEST, "번째 면담 예약을 찾을 수 없습니다."),
+    INVALID_RESERVATION_CREW_ID(HttpStatus.BAD_REQUEST, "다른 크루의 예약에 접근할 수 없습니다."),
     INVALID_RESERVATION_DATE(HttpStatus.BAD_REQUEST, "면담 예약은 최소 하루 전에 가능 합니다."),
     INVALID_AVAILABLE_DATE_TIME(HttpStatus.BAD_REQUEST, "선택한 날짜는 해당 코치의 가능한 시간이 아닙니다."),
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다"),

--- a/backend/src/main/java/com/woowacourse/ternoko/common/exception/ExceptionType.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/common/exception/ExceptionType.java
@@ -12,6 +12,7 @@ public enum ExceptionType {
     CREW_NOT_FOUND(HttpStatus.BAD_REQUEST, "번째 크루를 찾을 수 없습니다."),
     RESERVATION_NOT_FOUND(HttpStatus.BAD_REQUEST, "번째 면담 예약을 찾을 수 없습니다."),
     INVALID_RESERVATION_CREW_ID(HttpStatus.BAD_REQUEST, "다른 크루의 예약에 접근할 수 없습니다."),
+    INVALID_RESERVATION_COACH_ID(HttpStatus.BAD_REQUEST, "다른 코치의 예약에 접근할 수 없습니다."),
     INVALID_RESERVATION_DATE(HttpStatus.BAD_REQUEST, "면담 예약은 최소 하루 전에 가능 합니다."),
     INVALID_AVAILABLE_DATE_TIME(HttpStatus.BAD_REQUEST, "선택한 날짜는 해당 코치의 가능한 시간이 아닙니다."),
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다"),

--- a/backend/src/main/java/com/woowacourse/ternoko/common/exception/InvalidReservationCoachIdException.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/common/exception/InvalidReservationCoachIdException.java
@@ -1,0 +1,8 @@
+package com.woowacourse.ternoko.common.exception;
+
+public class InvalidReservationCoachIdException extends BadRequestException {
+
+    public InvalidReservationCoachIdException(final ExceptionType exceptionType) {
+        super(exceptionType.getStatusCode(), exceptionType.getMessage());
+    }
+}

--- a/backend/src/main/java/com/woowacourse/ternoko/common/exception/InvalidReservationCrewIdException.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/common/exception/InvalidReservationCrewIdException.java
@@ -1,0 +1,8 @@
+package com.woowacourse.ternoko.common.exception;
+
+public class InvalidReservationCrewIdException extends BadRequestException {
+
+    public InvalidReservationCrewIdException(final ExceptionType exceptionType) {
+        super(exceptionType.getStatusCode(), exceptionType.getMessage());
+    }
+}

--- a/backend/src/main/java/com/woowacourse/ternoko/config/DatabaseInitializer.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/config/DatabaseInitializer.java
@@ -1,17 +1,13 @@
 package com.woowacourse.ternoko.config;
 
+import com.woowacourse.ternoko.domain.member.Coach;
+import com.woowacourse.ternoko.repository.CoachRepository;
 import java.util.ArrayList;
-
 import javax.annotation.PostConstruct;
-
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
-
-import com.woowacourse.ternoko.domain.member.Coach;
-import com.woowacourse.ternoko.repository.CoachRepository;
-
-import lombok.RequiredArgsConstructor;
 
 @Profile({"local", "dev"})
 @Component
@@ -34,30 +30,54 @@ public class DatabaseInitializer {
 
         public void dbInit() {
             ArrayList<Coach> coaches = new ArrayList<>(12);
-            coaches.add(new Coach(1L,"이름", "공원", "공원"+TEST_EMAIL,
-                "https://user-images.githubusercontent.com/26570275/177680173-9bb25eac-5922-407b-889b-bb49ac392c2a.png","안녕하세요."));
-            coaches.add(new Coach(2L,"이름", "네오", "네오"+TEST_EMAIL,
-                "https://user-images.githubusercontent.com/26570275/177680191-a4497404-c4cb-4f86-8c2c-f4f9c70bcaf7.png","안녕하세요."));
-            coaches.add(new Coach(3L,"이름", "브라운", "브라운"+TEST_EMAIL,
-                "https://user-images.githubusercontent.com/26570275/177680196-744300be-eb1b-4331-a74f-fdc41ff869d0.png","안녕하세요."));
-            coaches.add(new Coach(4L,"이름", "브리", "브리"+TEST_EMAIL,
-                "https://user-images.githubusercontent.com/43205258/177765431-63d39896-c8e1-42e8-a229-08309849f2ff.png","안녕하세요."));
-            coaches.add(new Coach(5L,"이름", "왼손", "왼손"+TEST_EMAIL,
-                "https://user-images.githubusercontent.com/26570275/177680204-6d12cae9-f038-4503-b9de-a75f4b4de456.png","안녕하세요."));
-            coaches.add(new Coach(6L,"이름", "워니", "워니"+TEST_EMAIL,
-                "https://user-images.githubusercontent.com/26570275/177680207-896f887b-5baf-47a5-b7ea-3b8c1bb5b8c3.png","안녕하세요."));
-            coaches.add(new Coach(7L,"이름", "제이슨", "제이슨"+TEST_EMAIL,
-                "https://user-images.githubusercontent.com/43205258/177760748-5e0e9efd-d063-4639-9a6d-f48e3a76f919.png","안녕하세요."));
-            coaches.add(new Coach(8L,"이름", "준", "준"+TEST_EMAIL,
-                "https://user-images.githubusercontent.com/26570275/177680212-63242449-1059-450b-96d8-a06b01a1aea5.png","안녕하세요."));
-            coaches.add(new Coach(9L,"이름", "토미", "토미"+TEST_EMAIL,
-                "https://user-images.githubusercontent.com/26570275/177680217-764aa425-72cb-4b04-adeb-f110121cdf60.png","안녕하세요."));
-            coaches.add(new Coach(10L,"이름", "포비", "포비"+TEST_EMAIL,
-                "https://user-images.githubusercontent.com/26570275/177680220-fd4258be-d317-4080-a6f6-eaaa58beef0e.png","안녕하세요."));
-            coaches.add(new Coach(11L,"이름", "구구", "구구"+TEST_EMAIL,
-                "https://user-images.githubusercontent.com/43205258/177739511-d427cb0c-5a8d-4bfb-9df1-945b4d32afb4.png","안녕하세요."));
-            coaches.add(new Coach(12L,"이름", "포코", "포코"+TEST_EMAIL,
-                "https://user-images.githubusercontent.com/54317630/177786158-226652b7-7b4a-462c-af3b-775811756c87.png","안녕하세요."));
+            coaches.add(new Coach(1L, "이름", "공원", "공원" + TEST_EMAIL,
+                    "U123456789",
+                    "https://user-images.githubusercontent.com/26570275/177680173-9bb25eac-5922-407b-889b-bb49ac392c2a.png",
+                    "안녕하세요."));
+            coaches.add(new Coach(2L, "이름", "네오", "네오" + TEST_EMAIL,
+                    "U123456789",
+                    "https://user-images.githubusercontent.com/26570275/177680191-a4497404-c4cb-4f86-8c2c-f4f9c70bcaf7.png",
+                    "안녕하세요."));
+            coaches.add(new Coach(3L, "이름", "브라운", "브라운" + TEST_EMAIL,
+                    "U123456789",
+                    "https://user-images.githubusercontent.com/26570275/177680196-744300be-eb1b-4331-a74f-fdc41ff869d0.png",
+                    "안녕하세요."));
+            coaches.add(new Coach(4L, "이름", "브리", "브리" + TEST_EMAIL,
+                    "U123456789",
+                    "https://user-images.githubusercontent.com/43205258/177765431-63d39896-c8e1-42e8-a229-08309849f2ff.png",
+                    "안녕하세요."));
+            coaches.add(new Coach(5L, "이름", "왼손", "왼손" + TEST_EMAIL,
+                    "U123456789",
+                    "https://user-images.githubusercontent.com/26570275/177680204-6d12cae9-f038-4503-b9de-a75f4b4de456.png",
+                    "안녕하세요."));
+            coaches.add(new Coach(6L, "이름", "워니", "워니" + TEST_EMAIL,
+                    "U123456789",
+                    "https://user-images.githubusercontent.com/26570275/177680207-896f887b-5baf-47a5-b7ea-3b8c1bb5b8c3.png",
+                    "안녕하세요."));
+            coaches.add(new Coach(7L, "이름", "제이슨", "제이슨" + TEST_EMAIL,
+                    "U123456789",
+                    "https://user-images.githubusercontent.com/43205258/177760748-5e0e9efd-d063-4639-9a6d-f48e3a76f919.png",
+                    "안녕하세요."));
+            coaches.add(new Coach(8L, "이름", "준", "준" + TEST_EMAIL,
+                    "U123456789",
+                    "https://user-images.githubusercontent.com/26570275/177680212-63242449-1059-450b-96d8-a06b01a1aea5.png",
+                    "안녕하세요."));
+            coaches.add(new Coach(9L, "이름", "토미", "토미" + TEST_EMAIL,
+                    "U123456789",
+                    "https://user-images.githubusercontent.com/26570275/177680217-764aa425-72cb-4b04-adeb-f110121cdf60.png",
+                    "안녕하세요."));
+            coaches.add(new Coach(10L, "이름", "포비", "포비" + TEST_EMAIL,
+                    "U123456789",
+                    "https://user-images.githubusercontent.com/26570275/177680220-fd4258be-d317-4080-a6f6-eaaa58beef0e.png",
+                    "안녕하세요."));
+            coaches.add(new Coach(11L, "이름", "구구", "구구" + TEST_EMAIL,
+                    "U123456789",
+                    "https://user-images.githubusercontent.com/43205258/177739511-d427cb0c-5a8d-4bfb-9df1-945b4d32afb4.png",
+                    "안녕하세요."));
+            coaches.add(new Coach(12L, "이름", "포코", "포코" + TEST_EMAIL,
+                    "U123456789",
+                    "https://user-images.githubusercontent.com/54317630/177786158-226652b7-7b4a-462c-af3b-775811756c87.png",
+                    "안녕하세요."));
             coachRepository.saveAll(coaches);
         }
     }

--- a/backend/src/main/java/com/woowacourse/ternoko/config/DatabaseInitializer.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/config/DatabaseInitializer.java
@@ -1,7 +1,17 @@
 package com.woowacourse.ternoko.config;
 
+import com.woowacourse.ternoko.domain.AvailableDateTime;
 import com.woowacourse.ternoko.domain.member.Coach;
+import com.woowacourse.ternoko.domain.member.Crew;
+import com.woowacourse.ternoko.repository.AvailableDateTimeRepository;
 import com.woowacourse.ternoko.repository.CoachRepository;
+import com.woowacourse.ternoko.repository.CrewRepository;
+import com.woowacourse.ternoko.repository.FormItemRepository;
+import com.woowacourse.ternoko.repository.InterviewRepository;
+import com.woowacourse.ternoko.repository.ReservationRepository;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.ArrayList;
 import javax.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
@@ -27,13 +37,16 @@ public class DatabaseInitializer {
     @RequiredArgsConstructor
     static class InitService {
         private final CoachRepository coachRepository;
+        private final CrewRepository crewRepository;
+        private final AvailableDateTimeRepository availableDateTimeRepository;
 
         public void dbInit() {
             ArrayList<Coach> coaches = new ArrayList<>(12);
-            coaches.add(new Coach(1L, "이름", "공원", "공원" + TEST_EMAIL,
+            Coach coach1 = new Coach(1L, "이름", "공원", "공원" + TEST_EMAIL,
                     "U123456789",
                     "https://user-images.githubusercontent.com/26570275/177680173-9bb25eac-5922-407b-889b-bb49ac392c2a.png",
-                    "안녕하세요."));
+                    "안녕하세요.");
+            coaches.add(coach1);
             coaches.add(new Coach(2L, "이름", "네오", "네오" + TEST_EMAIL,
                     "U123456789",
                     "https://user-images.githubusercontent.com/26570275/177680191-a4497404-c4cb-4f86-8c2c-f4f9c70bcaf7.png",
@@ -78,7 +91,12 @@ public class DatabaseInitializer {
                     "U123456789",
                     "https://user-images.githubusercontent.com/54317630/177786158-226652b7-7b4a-462c-af3b-775811756c87.png",
                     "안녕하세요."));
+
             coachRepository.saveAll(coaches);
+            crewRepository.save(new Crew(13L, "사현빈", "바니", "shb1833@gmail.com", "U03N6FKQEJX",
+                    "https://a.slack-edge.com/80588/img/avatars-teams/ava_0012-230.png"));
+
+            availableDateTimeRepository.save(new AvailableDateTime(1L, coach1, LocalDateTime.of(LocalDate.of(2022, 8,25), LocalTime.of(11, 0))));
         }
     }
 }

--- a/backend/src/main/java/com/woowacourse/ternoko/config/DatabaseInitializer.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/config/DatabaseInitializer.java
@@ -43,52 +43,52 @@ public class DatabaseInitializer {
         public void dbInit() {
             ArrayList<Coach> coaches = new ArrayList<>(12);
             Coach coach1 = new Coach(1L, "이름", "공원", "공원" + TEST_EMAIL,
-                    "U123456789",
+                    "U1234567890",
                     "https://user-images.githubusercontent.com/26570275/177680173-9bb25eac-5922-407b-889b-bb49ac392c2a.png",
                     "안녕하세요.");
             coaches.add(coach1);
             coaches.add(new Coach(2L, "이름", "네오", "네오" + TEST_EMAIL,
-                    "U123456789",
+                    "U1234567891",
                     "https://user-images.githubusercontent.com/26570275/177680191-a4497404-c4cb-4f86-8c2c-f4f9c70bcaf7.png",
                     "안녕하세요."));
             coaches.add(new Coach(3L, "이름", "브라운", "브라운" + TEST_EMAIL,
-                    "U123456789",
+                    "U1234567892",
                     "https://user-images.githubusercontent.com/26570275/177680196-744300be-eb1b-4331-a74f-fdc41ff869d0.png",
                     "안녕하세요."));
             coaches.add(new Coach(4L, "이름", "브리", "브리" + TEST_EMAIL,
-                    "U123456789",
+                    "U1234567893",
                     "https://user-images.githubusercontent.com/43205258/177765431-63d39896-c8e1-42e8-a229-08309849f2ff.png",
                     "안녕하세요."));
             coaches.add(new Coach(5L, "이름", "왼손", "왼손" + TEST_EMAIL,
-                    "U123456789",
+                    "U1234567894",
                     "https://user-images.githubusercontent.com/26570275/177680204-6d12cae9-f038-4503-b9de-a75f4b4de456.png",
                     "안녕하세요."));
             coaches.add(new Coach(6L, "이름", "워니", "워니" + TEST_EMAIL,
-                    "U123456789",
+                    "U1234567895",
                     "https://user-images.githubusercontent.com/26570275/177680207-896f887b-5baf-47a5-b7ea-3b8c1bb5b8c3.png",
                     "안녕하세요."));
             coaches.add(new Coach(7L, "이름", "제이슨", "제이슨" + TEST_EMAIL,
-                    "U123456789",
+                    "U1234567896",
                     "https://user-images.githubusercontent.com/43205258/177760748-5e0e9efd-d063-4639-9a6d-f48e3a76f919.png",
                     "안녕하세요."));
             coaches.add(new Coach(8L, "이름", "준", "준" + TEST_EMAIL,
-                    "U123456789",
+                    "U1234567897",
                     "https://user-images.githubusercontent.com/26570275/177680212-63242449-1059-450b-96d8-a06b01a1aea5.png",
                     "안녕하세요."));
             coaches.add(new Coach(9L, "이름", "토미", "토미" + TEST_EMAIL,
-                    "U123456789",
+                    "U1234567898",
                     "https://user-images.githubusercontent.com/26570275/177680217-764aa425-72cb-4b04-adeb-f110121cdf60.png",
                     "안녕하세요."));
             coaches.add(new Coach(10L, "이름", "포비", "포비" + TEST_EMAIL,
-                    "U123456789",
+                    "U1234567899",
                     "https://user-images.githubusercontent.com/26570275/177680220-fd4258be-d317-4080-a6f6-eaaa58beef0e.png",
                     "안녕하세요."));
             coaches.add(new Coach(11L, "이름", "구구", "구구" + TEST_EMAIL,
-                    "U123456789",
+                    "U12345678910",
                     "https://user-images.githubusercontent.com/43205258/177739511-d427cb0c-5a8d-4bfb-9df1-945b4d32afb4.png",
                     "안녕하세요."));
             coaches.add(new Coach(12L, "이름", "포코", "포코" + TEST_EMAIL,
-                    "U123456789",
+                    "U12345678911",
                     "https://user-images.githubusercontent.com/54317630/177786158-226652b7-7b4a-462c-af3b-775811756c87.png",
                     "안녕하세요."));
 

--- a/backend/src/main/java/com/woowacourse/ternoko/config/DatabaseInitializer.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/config/DatabaseInitializer.java
@@ -97,6 +97,7 @@ public class DatabaseInitializer {
                     "https://a.slack-edge.com/80588/img/avatars-teams/ava_0012-230.png"));
 
             availableDateTimeRepository.save(new AvailableDateTime(1L, coach1, LocalDateTime.of(LocalDate.of(2022, 8,25), LocalTime.of(11, 0))));
+            availableDateTimeRepository.save(new AvailableDateTime(2L, coach1, LocalDateTime.of(LocalDate.of(2022, 8,25), LocalTime.of(13, 0))));
         }
     }
 }

--- a/backend/src/main/java/com/woowacourse/ternoko/controller/MemberController.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/controller/MemberController.java
@@ -25,7 +25,7 @@ public class MemberController {
     }
 
     @GetMapping("/login/check")
-    public ResponseEntity<NicknameResponse> checkUniqueNickname(@RequestParam String nickname) {
+    public ResponseEntity<NicknameResponse> checkUniqueNickname(@RequestParam final String nickname) {
         return ResponseEntity.ok(memberService.hasNickname(nickname));
     }
 }

--- a/backend/src/main/java/com/woowacourse/ternoko/controller/ReservationController.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/controller/ReservationController.java
@@ -1,8 +1,14 @@
 package com.woowacourse.ternoko.controller;
 
+import com.woowacourse.ternoko.config.AuthenticationPrincipal;
+import com.woowacourse.ternoko.domain.Reservation;
+import com.woowacourse.ternoko.dto.ReservationResponse;
+import com.woowacourse.ternoko.dto.request.ReservationRequest;
+import com.woowacourse.ternoko.service.ReservationService;
+import com.woowacourse.ternoko.support.SlackAlarm;
 import java.net.URI;
 import java.util.List;
-
+import lombok.AllArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -11,39 +17,35 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.woowacourse.ternoko.dto.ReservationResponse;
-import com.woowacourse.ternoko.dto.request.ReservationRequest;
-import com.woowacourse.ternoko.service.ReservationService;
-
-import lombok.AllArgsConstructor;
-
 @RestController
 @AllArgsConstructor
 @RequestMapping("/api/reservations")
 public class ReservationController {
 
-	private final ReservationService reservationService;
+    private final ReservationService reservationService;
+    private final SlackAlarm slackAlarm;
 
-	@PostMapping("/coaches/{coachId}")
-	public ResponseEntity<Void> createReservation(@PathVariable final Long coachId,
-		@RequestBody final ReservationRequest reservationRequest) {
-		final Long reservationId = reservationService.create(coachId, reservationRequest);
+    @PostMapping("/coaches/{coachId}")
+    public ResponseEntity<Void> createReservation(@AuthenticationPrincipal final Long crewId,
+                                                  @PathVariable final Long coachId,
+                                                  @RequestBody final ReservationRequest reservationRequest) {
+        final Reservation reservation = reservationService.create(crewId, coachId, reservationRequest);
 
-		return ResponseEntity.created(URI.create("/api/reservations/" + reservationId)).build();
-	}
+        return ResponseEntity.created(URI.create("/api/reservations/" + reservation.getId())).build();
+    }
 
-	@GetMapping("/{reservationId}")
-	public ResponseEntity<ReservationResponse> findReservationById(@PathVariable final Long reservationId) {
-		final ReservationResponse reservationResponse = reservationService.findReservationById(reservationId);
+    @GetMapping("/{reservationId}")
+    public ResponseEntity<ReservationResponse> findReservationById(@PathVariable final Long reservationId) {
+        final ReservationResponse reservationResponse = reservationService.findReservationById(reservationId);
 
-		return ResponseEntity.ok(reservationResponse);
-	}
+        return ResponseEntity.ok(reservationResponse);
+    }
 
-	@GetMapping
-	public ResponseEntity<List<ReservationResponse>> findAllReservations() {
-		final List<ReservationResponse> reservationResponses = reservationService.findAllReservations();
+    @GetMapping
+    public ResponseEntity<List<ReservationResponse>> findAllReservations() {
+        final List<ReservationResponse> reservationResponses = reservationService.findAllReservations();
 
-		return ResponseEntity.ok(reservationResponses);
-	}
+        return ResponseEntity.ok(reservationResponses);
+    }
 }
 

--- a/backend/src/main/java/com/woowacourse/ternoko/controller/ReservationController.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/controller/ReservationController.java
@@ -10,6 +10,7 @@ import java.net.URI;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -59,5 +60,14 @@ public class ReservationController {
         slackAlarm.sendAlarmWhenUpdatedReservationToCrew(updateReservation);
         slackAlarm.sendAlarmWhenUpdatedReservationToCoach(updateReservation);
         return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/{reservationId}")
+    public ResponseEntity<Void> updateReservation(@AuthenticationPrincipal final Long crewId,
+                                                  @PathVariable Long reservationId) throws Exception {
+        Reservation reservation = reservationService.delete(crewId, reservationId);
+        slackAlarm.sendAlarmWhenDeletedReservationToCrew(reservation);
+        slackAlarm.sendAlarmWhenDeletedReservationToCoach(reservation);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/backend/src/main/java/com/woowacourse/ternoko/controller/ReservationController.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/controller/ReservationController.java
@@ -25,11 +25,10 @@ public class ReservationController {
     private final ReservationService reservationService;
     private final SlackAlarm slackAlarm;
 
-    @PostMapping("/coaches/{coachId}")
+    @PostMapping
     public ResponseEntity<Void> createReservation(@AuthenticationPrincipal final Long crewId,
-                                                  @PathVariable final Long coachId,
                                                   @RequestBody final ReservationRequest reservationRequest) throws Exception {
-        final Reservation reservation = reservationService.create(crewId, coachId, reservationRequest);
+        final Reservation reservation = reservationService.create(crewId, reservationRequest);
         slackAlarm.sendAlarmWhenCreatedReservationToCrew(reservation);
         slackAlarm.sendAlarmWhenCreatedReservationToCoach(reservation);
         return ResponseEntity.created(URI.create("/api/reservations/" + reservation.getId())).build();

--- a/backend/src/main/java/com/woowacourse/ternoko/controller/ReservationController.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/controller/ReservationController.java
@@ -53,9 +53,11 @@ public class ReservationController {
     @PutMapping("/{reservationId}")
     public ResponseEntity<Void> updateReservation(@AuthenticationPrincipal final Long crewId,
                                                   @PathVariable Long reservationId,
-                                                  @RequestBody final ReservationRequest reservationRequest) {
-        reservationService.update(crewId, reservationId, reservationRequest);
+                                                  @RequestBody final ReservationRequest reservationRequest)
+            throws Exception {
+        Reservation updateReservation = reservationService.update(crewId, reservationId, reservationRequest);
+        slackAlarm.sendAlarmWhenUpdatedReservationToCrew(updateReservation);
+        slackAlarm.sendAlarmWhenUpdatedReservationToCoach(updateReservation);
         return ResponseEntity.ok().build();
     }
 }
-

--- a/backend/src/main/java/com/woowacourse/ternoko/controller/ReservationController.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/controller/ReservationController.java
@@ -6,6 +6,7 @@ import com.woowacourse.ternoko.domain.Reservation;
 import com.woowacourse.ternoko.dto.ReservationResponse;
 import com.woowacourse.ternoko.dto.request.ReservationRequest;
 import com.woowacourse.ternoko.service.ReservationService;
+import com.woowacourse.ternoko.support.AlarmMessage;
 import com.woowacourse.ternoko.support.SlackAlarm;
 import java.net.URI;
 import java.util.List;
@@ -34,8 +35,7 @@ public class ReservationController {
                                                   @RequestBody final ReservationRequest reservationRequest)
             throws Exception {
         final Reservation reservation = reservationService.create(crewId, reservationRequest);
-        slackAlarm.sendAlarmWhenCreatedReservationToCrew(reservation);
-        slackAlarm.sendAlarmWhenCreatedReservationToCoach(reservation);
+        slackAlarm.sendMessage(reservation.getInterview(), AlarmMessage.CREW_CREATE.getMessage());
         return ResponseEntity.created(URI.create("/api/reservations/" + reservation.getId())).build();
     }
 
@@ -59,8 +59,7 @@ public class ReservationController {
                                                   @RequestBody final ReservationRequest reservationRequest)
             throws Exception {
         Reservation updateReservation = reservationService.update(crewId, reservationId, reservationRequest);
-        slackAlarm.sendAlarmWhenUpdatedReservationToCrew(updateReservation);
-        slackAlarm.sendAlarmWhenUpdatedReservationToCoach(updateReservation);
+        slackAlarm.sendMessage(updateReservation.getInterview(), AlarmMessage.CREW_UPDATE.getMessage());
         return ResponseEntity.ok().build();
     }
 
@@ -68,8 +67,7 @@ public class ReservationController {
     public ResponseEntity<Void> deleteReservation(@AuthenticationPrincipal final Long crewId,
                                                   @PathVariable Long reservationId) throws Exception {
         Reservation reservation = reservationService.delete(crewId, reservationId);
-        slackAlarm.sendAlarmWhenDeletedReservationToCrew(reservation);
-        slackAlarm.sendAlarmWhenDeletedReservationToCoach(reservation);
+        slackAlarm.sendMessage(reservation.getInterview(), AlarmMessage.CREW_DELETE.getMessage());
         return ResponseEntity.noContent().build();
     }
 
@@ -77,8 +75,7 @@ public class ReservationController {
     public ResponseEntity<Void> cancelReservation(@AuthenticationPrincipal final Long coachId,
                                                   @PathVariable Long reservationId) throws Exception {
         Interview interview = reservationService.cancel(coachId, reservationId);
-        slackAlarm.sendAlarmWhenCanceledReservationToCrew(interview);
-        slackAlarm.sendAlarmWhenCanceledReservationToCoach(interview);
+        slackAlarm.sendMessage(interview, AlarmMessage.COACH_CANCEL.getMessage());
         return ResponseEntity.noContent().build();
     }
 }

--- a/backend/src/main/java/com/woowacourse/ternoko/controller/ReservationController.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/controller/ReservationController.java
@@ -28,9 +28,10 @@ public class ReservationController {
     @PostMapping("/coaches/{coachId}")
     public ResponseEntity<Void> createReservation(@AuthenticationPrincipal final Long crewId,
                                                   @PathVariable final Long coachId,
-                                                  @RequestBody final ReservationRequest reservationRequest) {
+                                                  @RequestBody final ReservationRequest reservationRequest) throws Exception {
         final Reservation reservation = reservationService.create(crewId, coachId, reservationRequest);
-
+        slackAlarm.sendAlarmWhenCreatedReservationToCrew(reservation);
+        slackAlarm.sendAlarmWhenCreatedReservationToCoach(reservation);
         return ResponseEntity.created(URI.create("/api/reservations/" + reservation.getId())).build();
     }
 

--- a/backend/src/main/java/com/woowacourse/ternoko/controller/ReservationController.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/controller/ReservationController.java
@@ -13,6 +13,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -27,7 +28,8 @@ public class ReservationController {
 
     @PostMapping
     public ResponseEntity<Void> createReservation(@AuthenticationPrincipal final Long crewId,
-                                                  @RequestBody final ReservationRequest reservationRequest) throws Exception {
+                                                  @RequestBody final ReservationRequest reservationRequest)
+            throws Exception {
         final Reservation reservation = reservationService.create(crewId, reservationRequest);
         slackAlarm.sendAlarmWhenCreatedReservationToCrew(reservation);
         slackAlarm.sendAlarmWhenCreatedReservationToCoach(reservation);
@@ -46,6 +48,14 @@ public class ReservationController {
         final List<ReservationResponse> reservationResponses = reservationService.findAllReservations();
 
         return ResponseEntity.ok(reservationResponses);
+    }
+
+    @PutMapping("/{reservationId}")
+    public ResponseEntity<Void> updateReservation(@AuthenticationPrincipal final Long crewId,
+                                                  @PathVariable Long reservationId,
+                                                  @RequestBody final ReservationRequest reservationRequest) {
+        reservationService.update(crewId, reservationId, reservationRequest);
+        return ResponseEntity.ok().build();
     }
 }
 

--- a/backend/src/main/java/com/woowacourse/ternoko/controller/ReservationController.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/controller/ReservationController.java
@@ -55,7 +55,7 @@ public class ReservationController {
 
     @PutMapping("/{reservationId}")
     public ResponseEntity<Void> updateReservation(@AuthenticationPrincipal final Long crewId,
-                                                  @PathVariable Long reservationId,
+                                                  @PathVariable final Long reservationId,
                                                   @RequestBody final ReservationRequest reservationRequest)
             throws Exception {
         Reservation updateReservation = reservationService.update(crewId, reservationId, reservationRequest);
@@ -65,7 +65,7 @@ public class ReservationController {
 
     @DeleteMapping("/{reservationId}")
     public ResponseEntity<Void> deleteReservation(@AuthenticationPrincipal final Long crewId,
-                                                  @PathVariable Long reservationId) throws Exception {
+                                                  @PathVariable final Long reservationId) throws Exception {
         Reservation reservation = reservationService.delete(crewId, reservationId);
         slackAlarm.sendMessage(reservation.getInterview(), AlarmMessage.CREW_DELETE.getMessage());
         return ResponseEntity.noContent().build();
@@ -73,7 +73,7 @@ public class ReservationController {
 
     @PatchMapping("/{reservationId}")
     public ResponseEntity<Void> cancelReservation(@AuthenticationPrincipal final Long coachId,
-                                                  @PathVariable Long reservationId) throws Exception {
+                                                  @PathVariable final Long reservationId) throws Exception {
         Interview interview = reservationService.cancel(coachId, reservationId);
         slackAlarm.sendMessage(interview, AlarmMessage.COACH_CANCEL.getMessage());
         return ResponseEntity.noContent().build();

--- a/backend/src/main/java/com/woowacourse/ternoko/controller/ReservationController.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/controller/ReservationController.java
@@ -1,6 +1,7 @@
 package com.woowacourse.ternoko.controller;
 
 import com.woowacourse.ternoko.config.AuthenticationPrincipal;
+import com.woowacourse.ternoko.domain.Interview;
 import com.woowacourse.ternoko.domain.Reservation;
 import com.woowacourse.ternoko.dto.ReservationResponse;
 import com.woowacourse.ternoko.dto.request.ReservationRequest;
@@ -12,6 +13,7 @@ import lombok.AllArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -63,11 +65,20 @@ public class ReservationController {
     }
 
     @DeleteMapping("/{reservationId}")
-    public ResponseEntity<Void> updateReservation(@AuthenticationPrincipal final Long crewId,
+    public ResponseEntity<Void> deleteReservation(@AuthenticationPrincipal final Long crewId,
                                                   @PathVariable Long reservationId) throws Exception {
         Reservation reservation = reservationService.delete(crewId, reservationId);
         slackAlarm.sendAlarmWhenDeletedReservationToCrew(reservation);
         slackAlarm.sendAlarmWhenDeletedReservationToCoach(reservation);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PatchMapping("/{reservationId}")
+    public ResponseEntity<Void> cancelReservation(@AuthenticationPrincipal final Long coachId,
+                                                  @PathVariable Long reservationId) throws Exception {
+        Interview interview = reservationService.cancel(coachId, reservationId);
+        slackAlarm.sendAlarmWhenCanceledReservationToCrew(interview);
+        slackAlarm.sendAlarmWhenCanceledReservationToCoach(interview);
         return ResponseEntity.noContent().build();
     }
 }

--- a/backend/src/main/java/com/woowacourse/ternoko/domain/FormItem.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/domain/FormItem.java
@@ -35,6 +35,12 @@ public class FormItem {
         this.answer = answer;
     }
 
+    public FormItem(Long id, String question, String answer) {
+        this.id = id;
+        this.question = question;
+        this.answer = answer;
+    }
+
     public FormItem(String question, String answer, Interview interview) {
         this.question = question;
         this.answer = answer;
@@ -44,5 +50,9 @@ public class FormItem {
     public void addInterview(final Interview interview) {
         this.interview = interview;
         interview.getFormItems().add(this);
+    }
+
+    public FormItem update(FormItem formItem) {
+        return new FormItem(this.id,  formItem.question, formItem.answer);
     }
 }

--- a/backend/src/main/java/com/woowacourse/ternoko/domain/FormItem.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/domain/FormItem.java
@@ -7,13 +7,14 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
-
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @Entity
 @NoArgsConstructor
+@AllArgsConstructor
 public class FormItem {
 
     @Id
@@ -52,7 +53,7 @@ public class FormItem {
         interview.getFormItems().add(this);
     }
 
-    public FormItem update(FormItem formItem) {
-        return new FormItem(this.id,  formItem.question, formItem.answer);
+    public FormItem update(FormItem formItem, Interview interview) {
+        return new FormItem(this.id, formItem.question, formItem.answer, interview);
     }
 }

--- a/backend/src/main/java/com/woowacourse/ternoko/domain/FormItem.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/domain/FormItem.java
@@ -53,7 +53,9 @@ public class FormItem {
         interview.getFormItems().add(this);
     }
 
-    public FormItem update(FormItem formItem, Interview interview) {
-        return new FormItem(this.id, formItem.question, formItem.answer, interview);
+    public void update(FormItem formItem, Interview interview) {
+        this.question = formItem.question;
+        this.answer = formItem.answer;
+        this.interview = interview;
     }
 }

--- a/backend/src/main/java/com/woowacourse/ternoko/domain/Interview.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/domain/Interview.java
@@ -2,7 +2,6 @@ package com.woowacourse.ternoko.domain;
 
 import com.woowacourse.ternoko.domain.member.Coach;
 import com.woowacourse.ternoko.domain.member.Crew;
-import com.woowacourse.ternoko.domain.member.Member;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -38,18 +37,11 @@ public class Interview {
     @JoinColumn(name = "coach_id")
     private Coach coach;
 
-//    @OneToOne
-//    @JoinColumn(name = "member_id")
-//    private Member coach;
-
     @OneToOne
     @JoinColumn(name = "crew_id")
     private Crew crew;
 
-//    @Column(nullable = false)
-//    private String crewNickname;
-
-    @OneToMany(mappedBy = "interview", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "interview", cascade = CascadeType.DETACH)
     private List<FormItem> formItems = new ArrayList<>();
 
 
@@ -94,25 +86,4 @@ public class Interview {
                 updateInterview.getCoach(),
                 updateInterview.getCrew());
     }
-//    public Interview(LocalDateTime interviewStartTime,
-//            LocalDateTime interviewEndTime,
-//            Member coach,
-//            String crewNickname,
-//            List<FormItem> formItems) {
-//        this.interviewStartTime = interviewStartTime;
-//        this.interviewEndTime = interviewEndTime;
-//        this.coach = coach;
-//        this.crewNickname = crewNickname;
-//        this.formItems = formItems;
-//    }
-
-//    public Interview(LocalDateTime interviewStartTime,
-//            LocalDateTime interviewEndTime,
-//            Member coach,
-//            String crewNickname) {
-//        this.interviewStartTime = interviewStartTime;
-//        this.interviewEndTime = interviewEndTime;
-//        this.coach = coach;
-//        this.crewNickname = crewNickname;
-//    }
 }

--- a/backend/src/main/java/com/woowacourse/ternoko/domain/Interview.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/domain/Interview.java
@@ -44,29 +44,35 @@ public class Interview {
     @OneToMany(mappedBy = "interview", cascade = CascadeType.DETACH)
     private List<FormItem> formItems = new ArrayList<>();
 
+    @Column(nullable = false)
+    private InterviewStatusType interviewStatusType;
 
     public Interview(final LocalDateTime interviewStartTime,
                      final LocalDateTime interviewEndTime,
                      final Coach coach,
                      final Crew crew,
-                     final List<FormItem> formItems) {
+                     final List<FormItem> formItems,
+                     final InterviewStatusType interviewStatusType) {
         this.interviewStartTime = interviewStartTime;
         this.interviewEndTime = interviewEndTime;
         this.coach = coach;
         this.crew = crew;
         this.formItems = formItems;
+        this.interviewStatusType = interviewStatusType;
     }
 
     public Interview(final Long id,
                      final LocalDateTime interviewStartTime,
                      final LocalDateTime interviewEndTime,
                      final Coach coach,
-                     final Crew crew) {
+                     final Crew crew,
+                     final InterviewStatusType interviewStatusType) {
         this.id = id;
         this.interviewStartTime = interviewStartTime;
         this.interviewEndTime = interviewEndTime;
         this.coach = coach;
         this.crew = crew;
+        this.interviewStatusType = interviewStatusType;
     }
 
     public Interview(final LocalDateTime interviewStartTime,
@@ -77,6 +83,7 @@ public class Interview {
         this.interviewEndTime = interviewEndTime;
         this.coach = coach;
         this.crew = crew;
+        this.interviewStatusType = InterviewStatusType.EDITABLE;
     }
 
     public Interview update(Interview updateInterview) {
@@ -84,6 +91,16 @@ public class Interview {
                 updateInterview.getInterviewStartTime(),
                 updateInterview.getInterviewEndTime(),
                 updateInterview.getCoach(),
-                updateInterview.getCrew());
+                updateInterview.getCrew(),
+                updateInterview.interviewStatusType);
+    }
+
+    public Interview cancel() {
+        return new Interview(this.id,
+                this.getInterviewStartTime(),
+                this.getInterviewEndTime(),
+                this.getCoach(),
+                this.getCrew(),
+                InterviewStatusType.CANCELED);
     }
 }

--- a/backend/src/main/java/com/woowacourse/ternoko/domain/Interview.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/domain/Interview.java
@@ -52,6 +52,7 @@ public class Interview {
     @OneToMany(mappedBy = "interview", cascade = CascadeType.ALL)
     private List<FormItem> formItems = new ArrayList<>();
 
+
     public Interview(final LocalDateTime interviewStartTime,
                      final LocalDateTime interviewEndTime,
                      final Coach coach,
@@ -64,6 +65,18 @@ public class Interview {
         this.formItems = formItems;
     }
 
+    public Interview(final Long id,
+                     final LocalDateTime interviewStartTime,
+                     final LocalDateTime interviewEndTime,
+                     final Coach coach,
+                     final Crew crew) {
+        this.id = id;
+        this.interviewStartTime = interviewStartTime;
+        this.interviewEndTime = interviewEndTime;
+        this.coach = coach;
+        this.crew = crew;
+    }
+
     public Interview(final LocalDateTime interviewStartTime,
                      final LocalDateTime interviewEndTime,
                      final Coach coach,
@@ -72,6 +85,14 @@ public class Interview {
         this.interviewEndTime = interviewEndTime;
         this.coach = coach;
         this.crew = crew;
+    }
+
+    public Interview update(Interview updateInterview) {
+        return new Interview(this.id,
+                updateInterview.getInterviewStartTime(),
+                updateInterview.getInterviewEndTime(),
+                updateInterview.getCoach(),
+                updateInterview.getCrew());
     }
 //    public Interview(LocalDateTime interviewStartTime,
 //            LocalDateTime interviewEndTime,

--- a/backend/src/main/java/com/woowacourse/ternoko/domain/Interview.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/domain/Interview.java
@@ -8,6 +8,8 @@ import java.util.List;
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -44,7 +46,7 @@ public class Interview {
     @OneToMany(mappedBy = "interview", cascade = CascadeType.DETACH)
     private List<FormItem> formItems = new ArrayList<>();
 
-    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
     private InterviewStatusType interviewStatusType;
 
     public Interview(final LocalDateTime interviewStartTime,

--- a/backend/src/main/java/com/woowacourse/ternoko/domain/Interview.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/domain/Interview.java
@@ -1,5 +1,7 @@
 package com.woowacourse.ternoko.domain;
 
+import com.woowacourse.ternoko.domain.member.Coach;
+import com.woowacourse.ternoko.domain.member.Crew;
 import com.woowacourse.ternoko.domain.member.Member;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -33,34 +35,63 @@ public class Interview {
     private LocalDateTime interviewEndTime;
 
     @OneToOne
-    @JoinColumn(name = "member_id")
-    private Member coach;
+    @JoinColumn(name = "coach_id")
+    private Coach coach;
 
-    @Column(nullable = false)
-    private String crewNickname;
+//    @OneToOne
+//    @JoinColumn(name = "member_id")
+//    private Member coach;
+
+    @OneToOne
+    @JoinColumn(name = "crew_id")
+    private Crew crew;
+
+//    @Column(nullable = false)
+//    private String crewNickname;
 
     @OneToMany(mappedBy = "interview", cascade = CascadeType.ALL)
     private List<FormItem> formItems = new ArrayList<>();
 
-    public Interview(LocalDateTime interviewStartTime,
-            LocalDateTime interviewEndTime,
-            Member coach,
-            String crewNickname,
-            List<FormItem> formItems) {
+    public Interview(final LocalDateTime interviewStartTime,
+                     final LocalDateTime interviewEndTime,
+                     final Coach coach,
+                     final Crew crew,
+                     final List<FormItem> formItems) {
         this.interviewStartTime = interviewStartTime;
         this.interviewEndTime = interviewEndTime;
         this.coach = coach;
-        this.crewNickname = crewNickname;
+        this.crew = crew;
         this.formItems = formItems;
     }
 
-    public Interview(LocalDateTime interviewStartTime,
-            LocalDateTime interviewEndTime,
-            Member coach,
-            String crewNickname) {
+    public Interview(final LocalDateTime interviewStartTime,
+                     final LocalDateTime interviewEndTime,
+                     final Coach coach,
+                     final Crew crew) {
         this.interviewStartTime = interviewStartTime;
         this.interviewEndTime = interviewEndTime;
         this.coach = coach;
-        this.crewNickname = crewNickname;
+        this.crew = crew;
     }
+//    public Interview(LocalDateTime interviewStartTime,
+//            LocalDateTime interviewEndTime,
+//            Member coach,
+//            String crewNickname,
+//            List<FormItem> formItems) {
+//        this.interviewStartTime = interviewStartTime;
+//        this.interviewEndTime = interviewEndTime;
+//        this.coach = coach;
+//        this.crewNickname = crewNickname;
+//        this.formItems = formItems;
+//    }
+
+//    public Interview(LocalDateTime interviewStartTime,
+//            LocalDateTime interviewEndTime,
+//            Member coach,
+//            String crewNickname) {
+//        this.interviewStartTime = interviewStartTime;
+//        this.interviewEndTime = interviewEndTime;
+//        this.coach = coach;
+//        this.crewNickname = crewNickname;
+//    }
 }

--- a/backend/src/main/java/com/woowacourse/ternoko/domain/Interview.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/domain/Interview.java
@@ -105,4 +105,12 @@ public class Interview {
                 this.getCrew(),
                 InterviewStatusType.CANCELED);
     }
+
+    public boolean sameCrew(Long crewId) {
+        return crew.sameMember(crewId);
+    }
+
+    public boolean sameCoach(Long coachId) {
+        return coach.sameMember(coachId);
+    }
 }

--- a/backend/src/main/java/com/woowacourse/ternoko/domain/Interview.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/domain/Interview.java
@@ -88,13 +88,13 @@ public class Interview {
         this.interviewStatusType = InterviewStatusType.EDITABLE;
     }
 
-    public Interview update(Interview updateInterview) {
-        return new Interview(this.id,
-                updateInterview.getInterviewStartTime(),
-                updateInterview.getInterviewEndTime(),
-                updateInterview.getCoach(),
-                updateInterview.getCrew(),
-                updateInterview.interviewStatusType);
+    public void update(Interview updateInterview) {
+
+        this.interviewStartTime = updateInterview.getInterviewStartTime();
+        this.interviewEndTime = updateInterview.getInterviewEndTime();
+        this.coach = updateInterview.getCoach();
+        this.crew = updateInterview.getCrew();
+        this.interviewStatusType = updateInterview.getInterviewStatusType();
     }
 
     public Interview cancel() {

--- a/backend/src/main/java/com/woowacourse/ternoko/domain/InterviewStatusType.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/domain/InterviewStatusType.java
@@ -5,5 +5,5 @@ public enum InterviewStatusType {
     FIX,
     FEEDBACK,
     COMPLETED,
-    CANCELED;
+    CANCELED
 }

--- a/backend/src/main/java/com/woowacourse/ternoko/domain/InterviewStatusType.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/domain/InterviewStatusType.java
@@ -1,0 +1,9 @@
+package com.woowacourse.ternoko.domain;
+
+public enum InterviewStatusType {
+    EDITABLE,
+    FIX,
+    FEEDBACK,
+    COMPLETED,
+    CANCELED;
+}

--- a/backend/src/main/java/com/woowacourse/ternoko/domain/Reservation.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/domain/Reservation.java
@@ -27,12 +27,18 @@ public class Reservation {
     @Column(nullable = false)
     private boolean isAccepted;
 
+    public Reservation(Long id, Interview interview, boolean isAccepted) {
+        this.id = id;
+        this.interview = interview;
+        this.isAccepted = isAccepted;
+    }
+
     public Reservation(Interview interview, boolean isAccepted) {
         this.interview = interview;
         this.isAccepted = isAccepted;
     }
 
     public Reservation update(Interview updatedInterview) {
-        return new Reservation(updatedInterview, false);
+        return new Reservation(this.id, updatedInterview, false);
     }
 }

--- a/backend/src/main/java/com/woowacourse/ternoko/domain/Reservation.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/domain/Reservation.java
@@ -38,8 +38,9 @@ public class Reservation {
         this.isAccepted = isAccepted;
     }
 
-    public Reservation update(Interview updatedInterview) {
-        return new Reservation(this.id, updatedInterview, false);
+    public void update(Interview updatedInterview) {
+        this.interview = updatedInterview;
+        this.isAccepted = false;
     }
 
     public boolean sameCrew(Long crewId) {

--- a/backend/src/main/java/com/woowacourse/ternoko/domain/Reservation.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/domain/Reservation.java
@@ -31,4 +31,8 @@ public class Reservation {
         this.interview = interview;
         this.isAccepted = isAccepted;
     }
+
+    public Reservation update(Interview updatedInterview) {
+        return new Reservation(updatedInterview, false);
+    }
 }

--- a/backend/src/main/java/com/woowacourse/ternoko/domain/Reservation.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/domain/Reservation.java
@@ -41,4 +41,12 @@ public class Reservation {
     public Reservation update(Interview updatedInterview) {
         return new Reservation(this.id, updatedInterview, false);
     }
+
+    public boolean sameCrew(Long crewId) {
+        return interview.sameCrew(crewId);
+    }
+
+    public boolean sameCoach(Long coachId) {
+        return interview.sameCoach(coachId);
+    }
 }

--- a/backend/src/main/java/com/woowacourse/ternoko/domain/member/Coach.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/domain/member/Coach.java
@@ -15,20 +15,20 @@ public class Coach extends Member {
     @Column
     private String introduce;
 
-    public Coach(final Long id, final String name, final String nickname, final String email, final String imageUrl,
-                 final String introduce) {
-        super(id, name, nickname, email, imageUrl);
+    public Coach(final Long id, final String name, final String nickname, final String email, final String userId,
+                 final String imageUrl, final String introduce) {
+        super(id, name, nickname, email, userId, imageUrl);
         this.introduce = introduce;
     }
 
-    public Coach(final String name, final String nickname, final String email, final String imageUrl,
-                 final String introduce) {
-        this(null, name, nickname, email, imageUrl, introduce);
+    public Coach(final String name, final String nickname, final String email, final String userId,
+                 final String imageUrl, final String introduce) {
+        this(null, name, nickname, email, userId, imageUrl, introduce);
 
     }
 
-    public Coach(final String name, final String email, final String imageUrl) {
-        this(null, name, null, email, imageUrl, null);
+    public Coach(final String name, final String email, final String userId, final String imageUrl) {
+        this(null, name, null, email, userId, imageUrl, null);
     }
 
 }

--- a/backend/src/main/java/com/woowacourse/ternoko/domain/member/Coach.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/domain/member/Coach.java
@@ -15,19 +15,31 @@ public class Coach extends Member {
     @Column
     private String introduce;
 
-    public Coach(final Long id, final String name, final String nickname, final String email, final String userId,
-                 final String imageUrl, final String introduce) {
+    public Coach(final Long id,
+                 final String name,
+                 final String nickname,
+                 final String email,
+                 final String userId,
+                 final String imageUrl,
+                 final String introduce) {
         super(id, name, nickname, email, userId, imageUrl);
         this.introduce = introduce;
     }
 
-    public Coach(final String name, final String nickname, final String email, final String userId,
-                 final String imageUrl, final String introduce) {
+    public Coach(final String name,
+                 final String nickname,
+                 final String email,
+                 final String userId,
+                 final String imageUrl,
+                 final String introduce) {
         this(null, name, nickname, email, userId, imageUrl, introduce);
 
     }
 
-    public Coach(final String name, final String email, final String userId, final String imageUrl) {
+    public Coach(final String name,
+                 final String email,
+                 final String userId,
+                 final String imageUrl) {
         this(null, name, null, email, userId, imageUrl, null);
     }
 

--- a/backend/src/main/java/com/woowacourse/ternoko/domain/member/Crew.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/domain/member/Crew.java
@@ -9,17 +9,27 @@ import lombok.NoArgsConstructor;
 @DiscriminatorValue("CREW")
 public class Crew extends Member {
 
-    public Crew(final Long id, final String name, final String nickname, final String email, final String userId,
+    public Crew(final Long id,
+                final String name,
+                final String nickname,
+                final String email,
+                final String userId,
                 final String imageUrl) {
         super(id, name, nickname, email, userId, imageUrl);
     }
 
-    public Crew(final String name, final String nickname, final String email, final String userId,
+    public Crew(final String name,
+                final String nickname,
+                final String email,
+                final String userId,
                 final String imageUrl) {
         this(null, name, nickname, email, userId, imageUrl);
     }
 
-    public Crew(final String name, final String email, final String userId, final String imageUrl) {
+    public Crew(final String name,
+                final String email,
+                final String userId,
+                final String imageUrl) {
         this(null, name, null, email, userId, imageUrl);
     }
 }

--- a/backend/src/main/java/com/woowacourse/ternoko/domain/member/Crew.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/domain/member/Crew.java
@@ -9,15 +9,17 @@ import lombok.NoArgsConstructor;
 @DiscriminatorValue("CREW")
 public class Crew extends Member {
 
-    public Crew(final Long id, final String name, final String nickname, final String email, final String imageUrl) {
-        super(id, name, nickname, email, imageUrl);
+    public Crew(final Long id, final String name, final String nickname, final String email, final String userId,
+                final String imageUrl) {
+        super(id, name, nickname, email, userId, imageUrl);
     }
 
-    public Crew(final String name, final String nickname, final String email, final String imageUrl) {
-        this(null, name, nickname, email, imageUrl);
+    public Crew(final String name, final String nickname, final String email, final String userId,
+                final String imageUrl) {
+        this(null, name, nickname, email, userId, imageUrl);
     }
 
-    public Crew(final String name, final String email, final String imageUrl) {
-        this(null, name, null, email, imageUrl);
+    public Crew(final String name, final String email, final String userId, final String imageUrl) {
+        this(null, name, null, email, userId, imageUrl);
     }
 }

--- a/backend/src/main/java/com/woowacourse/ternoko/domain/member/Member.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/domain/member/Member.java
@@ -35,5 +35,8 @@ public class Member {
     private String email;
 
     @Column
+    private String userId;
+
+    @Column
     private String imageUrl;
 }

--- a/backend/src/main/java/com/woowacourse/ternoko/domain/member/Member.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/domain/member/Member.java
@@ -39,4 +39,8 @@ public class Member {
 
     @Column
     private String imageUrl;
+
+    public boolean sameMember(Long id) {
+        return this.id.equals(id);
+    }
 }

--- a/backend/src/main/java/com/woowacourse/ternoko/domain/member/Member.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/domain/member/Member.java
@@ -34,7 +34,7 @@ public class Member {
     @Column(nullable = false, unique = true)
     private String email;
 
-    @Column
+    @Column(unique = true)
     private String userId;
 
     @Column

--- a/backend/src/main/java/com/woowacourse/ternoko/dto/CalendarResponse.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/dto/CalendarResponse.java
@@ -24,7 +24,7 @@ public class CalendarResponse {
     public static CalendarResponse from(final Interview interview) {
         return CalendarResponse.calenderResponseBuilder()
                 .id(interview.getId())
-                .crewNickname(interview.getCrewNickname())
+                .crewNickname(interview.getCrew().getNickname())
                 .interviewStartTime(
                         interview.getInterviewStartTime())
                 .interviewEndTime(

--- a/backend/src/main/java/com/woowacourse/ternoko/dto/ReservationResponse.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/dto/ReservationResponse.java
@@ -42,7 +42,7 @@ public class ReservationResponse {
                 .id(reservation.getId())
                 .coachNickname(interview.getCoach().getNickname())
                 .imageUrl(interview.getCoach().getImageUrl())
-                .crewNickname(interview.getCrewNickname())
+                .crewNickname(interview.getCrew().getNickname())
                 .interviewStartTime(interview.getInterviewStartTime())
                 .interviewEndTime(interview.getInterviewEndTime())
                 .interviewQuestions(formItemResponses)

--- a/backend/src/main/java/com/woowacourse/ternoko/dto/request/ReservationRequest.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/dto/request/ReservationRequest.java
@@ -12,7 +12,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class ReservationRequest {
 
-    private String crewNickname;
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
     private LocalDateTime interviewDatetime;
     private List<FormItemRequest> interviewQuestions;

--- a/backend/src/main/java/com/woowacourse/ternoko/dto/request/ReservationRequest.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/dto/request/ReservationRequest.java
@@ -12,6 +12,8 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class ReservationRequest {
 
+    private Long coachId;
+
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
     private LocalDateTime interviewDatetime;
     private List<FormItemRequest> interviewQuestions;

--- a/backend/src/main/java/com/woowacourse/ternoko/service/AuthService.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/service/AuthService.java
@@ -97,12 +97,12 @@ public class AuthService {
     private LoginResponse signUp(final OpenIDConnectUserInfoResponse userInfoResponse) {
         if (userInfoResponse.getEmail().contains(WOOWAHAN_COACH_EMAIL)) {
             final Coach coach = coachRepository.save(new Coach(userInfoResponse.getName(), userInfoResponse.getEmail(),
-                    userInfoResponse.getTeamImage230()));
+                    userInfoResponse.getUserId(), userInfoResponse.getTeamImage230()));
             return LoginResponse.of(Type.COACH, jwtProvider.createToken(String.valueOf(coach.getId())), false);
         }
 
         final Crew crew = crewRepository.save(new Crew(userInfoResponse.getName(), userInfoResponse.getEmail(),
-                userInfoResponse.getTeamImage230()));
+                userInfoResponse.getUserId(), userInfoResponse.getTeamImage230()));
 
         return LoginResponse.of(Type.CREW, jwtProvider.createToken(String.valueOf(crew.getId())), false);
     }

--- a/backend/src/main/java/com/woowacourse/ternoko/service/AuthService.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/service/AuthService.java
@@ -63,7 +63,7 @@ public class AuthService {
         if (member.isEmpty()) {
             return signUp(userInfoResponse);
         }
-        boolean hasNickname = !member.get().getNickname().isEmpty();
+        boolean hasNickname = member.get().getNickname() != null;
 
         if (coachRepository.findById(member.get().getId()).isPresent()) {
             return LoginResponse.of(Type.COACH, jwtProvider.createToken(String.valueOf(member.get().getId())),
@@ -75,24 +75,21 @@ public class AuthService {
 
     private OpenIDConnectUserInfoResponse getUserInfoResponseBySlack(final String code)
             throws IOException, SlackApiException {
-        final OpenIDConnectTokenResponse openIDConnectTokenResponse = getOpenIDTokenResponse(
-                code);
+        final OpenIDConnectTokenResponse openIDConnectTokenResponse = getOpenIDTokenResponse(code);
         final OpenIDConnectUserInfoRequest userInfoRequest = OpenIDConnectUserInfoRequest.builder()
                 .token(openIDConnectTokenResponse.getAccessToken())
                 .build();
         return slackMethodClient.openIDConnectUserInfo(userInfoRequest);
     }
 
-    private OpenIDConnectTokenResponse getOpenIDTokenResponse(final String code)
-            throws IOException, SlackApiException {
+    private OpenIDConnectTokenResponse getOpenIDTokenResponse(final String code) throws IOException, SlackApiException {
         final OpenIDConnectTokenRequest tokenRequest = OpenIDConnectTokenRequest.builder()
                 .clientId(clientId)
                 .clientSecret(clientSecret)
                 .code(code)
                 .redirectUri(redirectUrl)
                 .build();
-        return slackMethodClient.openIDConnectToken(
-                tokenRequest);
+        return slackMethodClient.openIDConnectToken(tokenRequest);
     }
 
     private LoginResponse signUp(final OpenIDConnectUserInfoResponse userInfoResponse) {

--- a/backend/src/main/java/com/woowacourse/ternoko/service/AuthService.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/service/AuthService.java
@@ -69,6 +69,7 @@ public class AuthService {
             return LoginResponse.of(Type.COACH, jwtProvider.createToken(String.valueOf(member.get().getId())),
                     hasNickname);
         }
+        System.out.println("Coach Token : "+ jwtProvider.createToken(String.valueOf(1L)));
         return LoginResponse.of(Type.CREW, jwtProvider.createToken(String.valueOf(member.get().getId())), hasNickname);
     }
 

--- a/backend/src/main/java/com/woowacourse/ternoko/service/AuthService.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/service/AuthService.java
@@ -69,7 +69,7 @@ public class AuthService {
             return LoginResponse.of(Type.COACH, jwtProvider.createToken(String.valueOf(member.get().getId())),
                     hasNickname);
         }
-        System.out.println("Coach Token : "+ jwtProvider.createToken(String.valueOf(1L)));
+
         return LoginResponse.of(Type.CREW, jwtProvider.createToken(String.valueOf(member.get().getId())), hasNickname);
     }
 

--- a/backend/src/main/java/com/woowacourse/ternoko/service/ReservationService.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/service/ReservationService.java
@@ -63,7 +63,8 @@ public class ReservationService {
         for (FormItem formItem : formItems) {
             formItem.addInterview(savedInterview);
         }
-
+        formItemRepository.saveAll(formItems);
+        ;
         final AvailableDateTime availableDateTime = findAvailableTime(reservationRequest);
         availableDateTimeRepository.delete(availableDateTime);
 
@@ -149,14 +150,18 @@ public class ReservationService {
 
         List<FormItem> updateFormItems = new ArrayList<>();
         for (int i = 0; i < originalInterviewFormItems.size(); i++) {
-            updateFormItems.add(originalInterviewFormItems.get(i).update(updateInterviewFormItemsRequest.get(i)));
+            updateFormItems.add(originalInterviewFormItems.get(i)
+                    .update(updateInterviewFormItemsRequest.get(i), originalInterview));
         }
         formItemRepository.saveAll(updateFormItems);
+
         Interview updatedInterview = interviewRepository.save(originalInterview.update(updateInterviewRequest));
+
         for (FormItem formItem : updateFormItems) {
             formItem.addInterview(updatedInterview);
         }
         availableDateTimeRepository.delete(availableDateTime);
+
         return reservationRepository.save(reservation.update(updatedInterview));
     }
 

--- a/backend/src/main/java/com/woowacourse/ternoko/service/ReservationService.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/service/ReservationService.java
@@ -152,19 +152,14 @@ public class ReservationService {
 
         List<FormItem> updateFormItems = new ArrayList<>();
         for (int i = 0; i < originalInterviewFormItems.size(); i++) {
-            updateFormItems.add(originalInterviewFormItems.get(i)
-                    .update(updateInterviewFormItemsRequest.get(i), originalInterview));
+            originalInterviewFormItems.get(i).update(updateInterviewFormItemsRequest.get(i), originalInterview);
         }
-        formItemRepository.saveAll(updateFormItems);
-
-        Interview updatedInterview = interviewRepository.save(originalInterview.update(updateInterviewRequest));
-
-        for (FormItem formItem : updateFormItems) {
-            formItem.addInterview(updatedInterview);
-        }
+        originalInterview.update(updateInterviewRequest);
         availableDateTimeRepository.delete(availableDateTime);
+        reservation.update(originalInterview);
 
-        return reservationRepository.save(reservation.update(updatedInterview));
+        return reservationRepository.findById(reservationId)
+                .orElseThrow(() -> new ReservationNotFoundException(RESERVATION_NOT_FOUND, reservationId));
     }
 
     public Reservation delete(final Long crewId, final Long reservationId) {

--- a/backend/src/main/java/com/woowacourse/ternoko/service/ReservationService.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/service/ReservationService.java
@@ -167,7 +167,7 @@ public class ReservationService {
         return reservationRepository.save(reservation.update(updatedInterview));
     }
 
-    public Reservation delete(Long crewId, Long reservationId) {
+    public Reservation delete(final Long crewId, final Long reservationId) {
         final Reservation reservation = reservationRepository.findById(reservationId)
                 .orElseThrow(() -> new ReservationNotFoundException(RESERVATION_NOT_FOUND, reservationId));
         if (!reservation.getInterview().getCrew().getId().equals(crewId)) {
@@ -183,7 +183,7 @@ public class ReservationService {
         return reservation;
     }
 
-    public Interview cancel(Long coachId, Long reservationId) {
+    public Interview cancel(final Long coachId, final Long reservationId) {
         final Reservation reservation = reservationRepository.findById(reservationId)
                 .orElseThrow(() -> new ReservationNotFoundException(RESERVATION_NOT_FOUND, reservationId));
         if (!reservation.getInterview().getCoach().getId().equals(coachId)) {
@@ -195,13 +195,13 @@ public class ReservationService {
         return interview;
     }
 
-    private AvailableDateTime findAvailableTime(ReservationRequest reservationRequest) {
+    private AvailableDateTime findAvailableTime(final ReservationRequest reservationRequest) {
         return availableDateTimeRepository.findByCoachIdAndInterviewDateTime(reservationRequest.getCoachId(),
                         reservationRequest.getInterviewDatetime())
                 .orElseThrow(() -> new InvalidReservationDateException(INVALID_AVAILABLE_DATE_TIME));
     }
 
-    private AvailableDateTime findAvailableTime(Long coachId, LocalDateTime interviewDatetime) {
+    private AvailableDateTime findAvailableTime(final Long coachId, final LocalDateTime interviewDatetime) {
         return availableDateTimeRepository.findByCoachIdAndInterviewDateTime(coachId, interviewDatetime)
                 .orElseThrow(() -> new InvalidReservationDateException(INVALID_AVAILABLE_DATE_TIME));
     }

--- a/backend/src/main/java/com/woowacourse/ternoko/service/ReservationService.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/service/ReservationService.java
@@ -138,7 +138,7 @@ public class ReservationService {
                               final ReservationRequest reservationRequest) {
         final Reservation reservation = reservationRepository.findById(reservationId)
                 .orElseThrow(() -> new ReservationNotFoundException(RESERVATION_NOT_FOUND, reservationId));
-        if (!reservation.getInterview().getCrew().getId().equals(crewId)) {
+        if (!reservation.sameCrew(crewId)) {
             throw new InvalidReservationCrewIdException(INVALID_RESERVATION_CREW_ID);
         }
 
@@ -170,7 +170,7 @@ public class ReservationService {
     public Reservation delete(final Long crewId, final Long reservationId) {
         final Reservation reservation = reservationRepository.findById(reservationId)
                 .orElseThrow(() -> new ReservationNotFoundException(RESERVATION_NOT_FOUND, reservationId));
-        if (!reservation.getInterview().getCrew().getId().equals(crewId)) {
+        if (!reservation.sameCrew(crewId)) {
             throw new InvalidReservationCrewIdException(INVALID_RESERVATION_CREW_ID);
         }
         formItemRepository.deleteAll(reservation.getInterview().getFormItems());
@@ -186,7 +186,7 @@ public class ReservationService {
     public Interview cancel(final Long coachId, final Long reservationId) {
         final Reservation reservation = reservationRepository.findById(reservationId)
                 .orElseThrow(() -> new ReservationNotFoundException(RESERVATION_NOT_FOUND, reservationId));
-        if (!reservation.getInterview().getCoach().getId().equals(coachId)) {
+        if (!reservation.sameCoach(coachId)) {
             throw new InvalidReservationCoachIdException(INVALID_RESERVATION_COACH_ID);
         }
         Interview interview = reservation.getInterview().cancel();

--- a/backend/src/main/java/com/woowacourse/ternoko/service/ReservationService.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/service/ReservationService.java
@@ -3,12 +3,14 @@ package com.woowacourse.ternoko.service;
 import static com.woowacourse.ternoko.common.exception.ExceptionType.COACH_NOT_FOUND;
 import static com.woowacourse.ternoko.common.exception.ExceptionType.CREW_NOT_FOUND;
 import static com.woowacourse.ternoko.common.exception.ExceptionType.INVALID_AVAILABLE_DATE_TIME;
+import static com.woowacourse.ternoko.common.exception.ExceptionType.INVALID_RESERVATION_COACH_ID;
 import static com.woowacourse.ternoko.common.exception.ExceptionType.INVALID_RESERVATION_CREW_ID;
 import static com.woowacourse.ternoko.common.exception.ExceptionType.INVALID_RESERVATION_DATE;
 import static com.woowacourse.ternoko.common.exception.ExceptionType.RESERVATION_NOT_FOUND;
 
 import com.woowacourse.ternoko.common.exception.CoachNotFoundException;
 import com.woowacourse.ternoko.common.exception.CrewNotFoundException;
+import com.woowacourse.ternoko.common.exception.InvalidReservationCoachIdException;
 import com.woowacourse.ternoko.common.exception.InvalidReservationCrewIdException;
 import com.woowacourse.ternoko.common.exception.InvalidReservationDateException;
 import com.woowacourse.ternoko.common.exception.ReservationNotFoundException;
@@ -64,7 +66,7 @@ public class ReservationService {
             formItem.addInterview(savedInterview);
         }
         formItemRepository.saveAll(formItems);
-        ;
+
         final AvailableDateTime availableDateTime = findAvailableTime(reservationRequest);
         availableDateTimeRepository.delete(availableDateTime);
 
@@ -179,6 +181,18 @@ public class ReservationService {
                 reservation.getInterview().getInterviewStartTime()));
 
         return reservation;
+    }
+
+    public Interview cancel(Long coachId, Long reservationId) {
+        final Reservation reservation = reservationRepository.findById(reservationId)
+                .orElseThrow(() -> new ReservationNotFoundException(RESERVATION_NOT_FOUND, reservationId));
+        if (!reservation.getInterview().getCoach().getId().equals(coachId)) {
+            throw new InvalidReservationCoachIdException(INVALID_RESERVATION_COACH_ID);
+        }
+        Interview interview = reservation.getInterview().cancel();
+
+        interviewRepository.save(interview);
+        return interview;
     }
 
     private AvailableDateTime findAvailableTime(ReservationRequest reservationRequest) {

--- a/backend/src/main/java/com/woowacourse/ternoko/support/AlarmMessage.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/support/AlarmMessage.java
@@ -1,0 +1,16 @@
+package com.woowacourse.ternoko.support;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum AlarmMessage {
+
+    CREW_CREATE("[예약 완료] %s, %s과의 면담이 %s에 예약되었습니다."),
+    CREW_UPDATE("[예약 수정] %s, %s과의 면담 예약이 %s로 수정되었습니다."),
+    COACH_CANCEL("[예약 취소] %s, %s과의 면담 예약(%s)이 취소되었습니다."),
+    CREW_DELETE("[예약 삭제] %s, %s과의 면담 예약(%s)이 삭제되었습니다.");
+
+    private final String message;
+}

--- a/backend/src/main/java/com/woowacourse/ternoko/support/SlackAlarm.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/support/SlackAlarm.java
@@ -1,0 +1,29 @@
+package com.woowacourse.ternoko.support;
+
+import com.slack.api.methods.impl.MethodsClientImpl;
+import com.slack.api.methods.request.chat.ChatPostMessageRequest;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SlackAlarm {
+
+    private final String botToken;
+
+    private final MethodsClientImpl slackMethodClient;
+
+    public SlackAlarm(final MethodsClientImpl slackMethodClient, @Value("${slack.botToken}") final String botToken) {
+        this.slackMethodClient = slackMethodClient;
+        this.botToken = botToken;
+    }
+
+    public void sendMessage(final String userId) throws Exception {
+
+        ChatPostMessageRequest request = ChatPostMessageRequest.builder()
+                .text("test 메시지 입니다.")
+                .channel(userId)
+                .token(botToken)
+                .build();
+        slackMethodClient.chatPostMessage(request);
+    }
+}

--- a/backend/src/main/java/com/woowacourse/ternoko/support/SlackAlarm.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/support/SlackAlarm.java
@@ -20,115 +20,23 @@ public class SlackAlarm {
         this.botToken = botToken;
     }
 
-    public void sendAlarmWhenCreatedReservationToCrew(final Reservation reservation) throws Exception {
-        LocalDateTime interviewStartTime = reservation.getInterview().getInterviewStartTime();
-        String coachNickname = reservation.getInterview().getCoach().getNickname();
-        String crewNickname = reservation.getInterview().getCrew().getNickname();
-        String msg = crewNickname + ", " + coachNickname + "과의 면담이 " + interviewStartTime + "에 예약되었습니다.";
-
-        ChatPostMessageRequest request = ChatPostMessageRequest.builder()
-                .text(msg)
-                .channel(reservation.getInterview().getCrew().getUserId())
-                .token(botToken)
-                .build();
-        slackMethodClient.chatPostMessage(request);
-    }
-
-    public void sendAlarmWhenCreatedReservationToCoach(final Reservation reservation) throws Exception {
-        LocalDateTime interviewStartTime = reservation.getInterview().getInterviewStartTime();
-        String coachNickname = reservation.getInterview().getCoach().getNickname();
-        String crewNickname = reservation.getInterview().getCrew().getNickname();
-        String msg = coachNickname + ", " + crewNickname + "과의 면담이 " + interviewStartTime + "에 예약되었습니다.";
-
-        ChatPostMessageRequest request = ChatPostMessageRequest.builder()
-                .text(msg)
-                .channel(reservation.getInterview().getCoach().getUserId())
-                .token(botToken)
-                .build();
-        slackMethodClient.chatPostMessage(request);
-    }
-
-    public void sendAlarmWhenUpdatedReservationToCrew(final Reservation reservation) throws Exception {
-        LocalDateTime interviewStartTime = reservation.getInterview().getInterviewStartTime();
-        String coachNickname = reservation.getInterview().getCoach().getNickname();
-        String crewNickname = reservation.getInterview().getCrew().getNickname();
-        String msg = crewNickname + ", " + coachNickname + "과의 면담 예약이 " + interviewStartTime + "로 수정되었습니다.";
-
-        ChatPostMessageRequest request = ChatPostMessageRequest.builder()
-                .text(msg)
-                .channel(reservation.getInterview().getCrew().getUserId())
-                .token(botToken)
-                .build();
-        slackMethodClient.chatPostMessage(request);
-    }
-
-    public void sendAlarmWhenUpdatedReservationToCoach(final Reservation reservation) throws Exception {
-        LocalDateTime interviewStartTime = reservation.getInterview().getInterviewStartTime();
-        String coachNickname = reservation.getInterview().getCoach().getNickname();
-        String crewNickname = reservation.getInterview().getCrew().getNickname();
-        String msg = coachNickname + ", " + crewNickname + "과의 면담 예약이 " + interviewStartTime + "로 수정되었습니다.";
-
-        ChatPostMessageRequest request = ChatPostMessageRequest.builder()
-                .text(msg)
-                .channel(reservation.getInterview().getCoach().getUserId())
-                .token(botToken)
-                .build();
-        slackMethodClient.chatPostMessage(request);
-    }
-
-    public void sendAlarmWhenDeletedReservationToCrew(final Reservation reservation) throws Exception {
-        LocalDateTime interviewStartTime = reservation.getInterview().getInterviewStartTime();
-        String coachNickname = reservation.getInterview().getCoach().getNickname();
-        String crewNickname = reservation.getInterview().getCrew().getNickname();
-        String msg = crewNickname + ", " + coachNickname + "과의 면담 예약(" + interviewStartTime + ")이 취소되었습니다.";
-
-        ChatPostMessageRequest request = ChatPostMessageRequest.builder()
-                .text(msg)
-                .channel(reservation.getInterview().getCrew().getUserId())
-                .token(botToken)
-                .build();
-        slackMethodClient.chatPostMessage(request);
-    }
-
-    public void sendAlarmWhenDeletedReservationToCoach(final Reservation reservation) throws Exception {
-        LocalDateTime interviewStartTime = reservation.getInterview().getInterviewStartTime();
-        String coachNickname = reservation.getInterview().getCoach().getNickname();
-        String crewNickname = reservation.getInterview().getCrew().getNickname();
-        String msg = coachNickname + ", " + crewNickname + "과의 면담 예약(" + interviewStartTime + ")이 취소되었습니다.";
-
-        ChatPostMessageRequest request = ChatPostMessageRequest.builder()
-                .text(msg)
-                .channel(reservation.getInterview().getCoach().getUserId())
-                .token(botToken)
-                .build();
-        slackMethodClient.chatPostMessage(request);
-    }
-
-    public void sendAlarmWhenCanceledReservationToCrew(final Interview interview) throws Exception {
+    public void sendMessage(final Interview interview, final String message) throws Exception {
         LocalDateTime interviewStartTime = interview.getInterviewStartTime();
         String coachNickname = interview.getCoach().getNickname();
         String crewNickname = interview.getCrew().getNickname();
-        String msg = crewNickname + ", " + coachNickname + "이(가) 면담 예약(" + interviewStartTime + ")이 취소하였습니다.";
 
-        ChatPostMessageRequest request = ChatPostMessageRequest.builder()
-                .text(msg)
+        ChatPostMessageRequest crewRequest = ChatPostMessageRequest.builder()
+                .text(String.format(message, coachNickname, crewNickname, interviewStartTime))
                 .channel(interview.getCrew().getUserId())
                 .token(botToken)
                 .build();
-        slackMethodClient.chatPostMessage(request);
-    }
+        slackMethodClient.chatPostMessage(crewRequest);
 
-    public void sendAlarmWhenCanceledReservationToCoach(final Interview interview) throws Exception {
-        LocalDateTime interviewStartTime = interview.getInterviewStartTime();
-        String coachNickname = interview.getCoach().getNickname();
-        String crewNickname = interview.getCrew().getNickname();
-        String msg = coachNickname + ", " + crewNickname + "과의 면담 예약(" + interviewStartTime + ")이 취소 완료되었습니다.";
-
-        ChatPostMessageRequest request = ChatPostMessageRequest.builder()
-                .text(msg)
+        ChatPostMessageRequest coachRequest = ChatPostMessageRequest.builder()
+                .text(String.format(message, crewNickname, coachNickname, interviewStartTime))
                 .channel(interview.getCoach().getUserId())
                 .token(botToken)
                 .build();
-        slackMethodClient.chatPostMessage(request);
+        slackMethodClient.chatPostMessage(coachRequest);
     }
 }

--- a/backend/src/main/java/com/woowacourse/ternoko/support/SlackAlarm.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/support/SlackAlarm.java
@@ -2,6 +2,8 @@ package com.woowacourse.ternoko.support;
 
 import com.slack.api.methods.impl.MethodsClientImpl;
 import com.slack.api.methods.request.chat.ChatPostMessageRequest;
+import com.woowacourse.ternoko.domain.Reservation;
+import java.time.LocalDateTime;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
@@ -17,11 +19,29 @@ public class SlackAlarm {
         this.botToken = botToken;
     }
 
-    public void sendMessage(final String userId) throws Exception {
+    public void sendAlarmWhenCreatedReservationToCrew(final Reservation reservation) throws Exception {
+        LocalDateTime interviewStartTime = reservation.getInterview().getInterviewStartTime();
+        String coachNickname = reservation.getInterview().getCoach().getNickname();
+        String crewNickname = reservation.getInterview().getCrew().getNickname();
+        String msg = crewNickname + ", " + coachNickname + "과의 면담이 " + interviewStartTime + "에 예약되었습니다.";
 
         ChatPostMessageRequest request = ChatPostMessageRequest.builder()
-                .text("test 메시지 입니다.")
-                .channel(userId)
+                .text(msg)
+                .channel(reservation.getInterview().getCrew().getUserId())
+                .token(botToken)
+                .build();
+        slackMethodClient.chatPostMessage(request);
+    }
+
+    public void sendAlarmWhenCreatedReservationToCoach(final Reservation reservation) throws Exception {
+        LocalDateTime interviewStartTime = reservation.getInterview().getInterviewStartTime();
+        String coachNickname = reservation.getInterview().getCoach().getNickname();
+        String crewNickname = reservation.getInterview().getCrew().getNickname();
+        String msg = coachNickname + ", " + crewNickname + "과의 면담이 " + interviewStartTime + "에 예약되었습니다.";
+
+        ChatPostMessageRequest request = ChatPostMessageRequest.builder()
+                .text(msg)
+                .channel(reservation.getInterview().getCoach().getUserId())
                 .token(botToken)
                 .build();
         slackMethodClient.chatPostMessage(request);

--- a/backend/src/main/java/com/woowacourse/ternoko/support/SlackAlarm.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/support/SlackAlarm.java
@@ -2,6 +2,7 @@ package com.woowacourse.ternoko.support;
 
 import com.slack.api.methods.impl.MethodsClientImpl;
 import com.slack.api.methods.request.chat.ChatPostMessageRequest;
+import com.woowacourse.ternoko.domain.Interview;
 import com.woowacourse.ternoko.domain.Reservation;
 import java.time.LocalDateTime;
 import org.springframework.beans.factory.annotation.Value;
@@ -98,6 +99,34 @@ public class SlackAlarm {
         ChatPostMessageRequest request = ChatPostMessageRequest.builder()
                 .text(msg)
                 .channel(reservation.getInterview().getCoach().getUserId())
+                .token(botToken)
+                .build();
+        slackMethodClient.chatPostMessage(request);
+    }
+
+    public void sendAlarmWhenCanceledReservationToCrew(final Interview interview) throws Exception {
+        LocalDateTime interviewStartTime = interview.getInterviewStartTime();
+        String coachNickname = interview.getCoach().getNickname();
+        String crewNickname = interview.getCrew().getNickname();
+        String msg = crewNickname + ", " + coachNickname + "이(가) 면담 예약(" + interviewStartTime + ")이 취소하였습니다.";
+
+        ChatPostMessageRequest request = ChatPostMessageRequest.builder()
+                .text(msg)
+                .channel(interview.getCrew().getUserId())
+                .token(botToken)
+                .build();
+        slackMethodClient.chatPostMessage(request);
+    }
+
+    public void sendAlarmWhenCanceledReservationToCoach(final Interview interview) throws Exception {
+        LocalDateTime interviewStartTime = interview.getInterviewStartTime();
+        String coachNickname = interview.getCoach().getNickname();
+        String crewNickname = interview.getCrew().getNickname();
+        String msg = coachNickname + ", " + crewNickname + "과의 면담 예약(" + interviewStartTime + ")이 취소 완료되었습니다.";
+
+        ChatPostMessageRequest request = ChatPostMessageRequest.builder()
+                .text(msg)
+                .channel(interview.getCoach().getUserId())
                 .token(botToken)
                 .build();
         slackMethodClient.chatPostMessage(request);

--- a/backend/src/main/java/com/woowacourse/ternoko/support/SlackAlarm.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/support/SlackAlarm.java
@@ -74,4 +74,32 @@ public class SlackAlarm {
                 .build();
         slackMethodClient.chatPostMessage(request);
     }
+
+    public void sendAlarmWhenDeletedReservationToCrew(final Reservation reservation) throws Exception {
+        LocalDateTime interviewStartTime = reservation.getInterview().getInterviewStartTime();
+        String coachNickname = reservation.getInterview().getCoach().getNickname();
+        String crewNickname = reservation.getInterview().getCrew().getNickname();
+        String msg = crewNickname + ", " + coachNickname + "과의 면담 예약(" + interviewStartTime + ")이 취소되었습니다.";
+
+        ChatPostMessageRequest request = ChatPostMessageRequest.builder()
+                .text(msg)
+                .channel(reservation.getInterview().getCrew().getUserId())
+                .token(botToken)
+                .build();
+        slackMethodClient.chatPostMessage(request);
+    }
+
+    public void sendAlarmWhenDeletedReservationToCoach(final Reservation reservation) throws Exception {
+        LocalDateTime interviewStartTime = reservation.getInterview().getInterviewStartTime();
+        String coachNickname = reservation.getInterview().getCoach().getNickname();
+        String crewNickname = reservation.getInterview().getCrew().getNickname();
+        String msg = coachNickname + ", " + crewNickname + "과의 면담 예약(" + interviewStartTime + ")이 취소되었습니다.";
+
+        ChatPostMessageRequest request = ChatPostMessageRequest.builder()
+                .text(msg)
+                .channel(reservation.getInterview().getCoach().getUserId())
+                .token(botToken)
+                .build();
+        slackMethodClient.chatPostMessage(request);
+    }
 }

--- a/backend/src/main/java/com/woowacourse/ternoko/support/SlackAlarm.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/support/SlackAlarm.java
@@ -46,4 +46,32 @@ public class SlackAlarm {
                 .build();
         slackMethodClient.chatPostMessage(request);
     }
+
+    public void sendAlarmWhenUpdatedReservationToCrew(final Reservation reservation) throws Exception {
+        LocalDateTime interviewStartTime = reservation.getInterview().getInterviewStartTime();
+        String coachNickname = reservation.getInterview().getCoach().getNickname();
+        String crewNickname = reservation.getInterview().getCrew().getNickname();
+        String msg = crewNickname + ", " + coachNickname + "과의 면담 예약이 " + interviewStartTime + "로 수정되었습니다.";
+
+        ChatPostMessageRequest request = ChatPostMessageRequest.builder()
+                .text(msg)
+                .channel(reservation.getInterview().getCrew().getUserId())
+                .token(botToken)
+                .build();
+        slackMethodClient.chatPostMessage(request);
+    }
+
+    public void sendAlarmWhenUpdatedReservationToCoach(final Reservation reservation) throws Exception {
+        LocalDateTime interviewStartTime = reservation.getInterview().getInterviewStartTime();
+        String coachNickname = reservation.getInterview().getCoach().getNickname();
+        String crewNickname = reservation.getInterview().getCrew().getNickname();
+        String msg = coachNickname + ", " + crewNickname + "과의 면담 예약이 " + interviewStartTime + "로 수정되었습니다.";
+
+        ChatPostMessageRequest request = ChatPostMessageRequest.builder()
+                .text(msg)
+                .channel(reservation.getInterview().getCoach().getUserId())
+                .token(botToken)
+                .build();
+        slackMethodClient.chatPostMessage(request);
+    }
 }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -3,10 +3,9 @@ spring:
     default: local
 
 slack:
-  redirectUrl: 'https://ternoko.site/api/login'
+  redirectUrl: 'https://localhost:8080/api/login'
   clientId: '3756998338916.3821665111344'
   clientSecret: '7db0d45bf9ae307a3a93522aa0cc4131'
-  botToken: 'xoxb-3756998338916-3842314970982-U836E93jZbDLX4qxj25mybQV'
 
 server:
   ssl:

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -6,7 +6,7 @@ slack:
   redirectUrl: 'https://localhost:8080/api/login'
   clientId: '3756998338916.3821665111344'
   clientSecret: '7db0d45bf9ae307a3a93522aa0cc4131'
-  botToken: 'xoxb-3756998338916-3842314970982-2gbLlR8ZCitbKyh0UUqaXYtB'
+  botToken: 'xoxb-3756998338916-3842314970982-ZIx3xN1Dr167rMdPKPqpM3W9'
 
 server:
   ssl:

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -3,10 +3,10 @@ spring:
     default: local
 
 slack:
-  redirectUrl: 'https://localhost:8080/api/login'
+  redirectUrl: 'https://ternoko.site/api/login'
   clientId: '3756998338916.3821665111344'
   clientSecret: '7db0d45bf9ae307a3a93522aa0cc4131'
-  botToken: 'xoxb-3756998338916-3842314970982-TeV0jfDkRCKO09JUadFkq2Xv'
+  botToken: 'xoxb-3756998338916-3842314970982-U836E93jZbDLX4qxj25mybQV'
 
 server:
   ssl:

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -6,6 +6,7 @@ slack:
   redirectUrl: 'https://localhost:8080/api/login'
   clientId: '3756998338916.3821665111344'
   clientSecret: '7db0d45bf9ae307a3a93522aa0cc4131'
+  botToken: 'xoxb-3756998338916-3842314970982-2gbLlR8ZCitbKyh0UUqaXYtB'
 
 server:
   ssl:

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -6,7 +6,7 @@ slack:
   redirectUrl: 'https://localhost:8080/api/login'
   clientId: '3756998338916.3821665111344'
   clientSecret: '7db0d45bf9ae307a3a93522aa0cc4131'
-  botToken: 'xoxb-3756998338916-3842314970982-ZIx3xN1Dr167rMdPKPqpM3W9'
+  botToken: 'xoxb-3756998338916-3842314970982-TeV0jfDkRCKO09JUadFkq2Xv'
 
 server:
   ssl:

--- a/backend/src/test/java/com/woowacourse/ternoko/acceptance/AcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/ternoko/acceptance/AcceptanceTest.java
@@ -11,6 +11,7 @@ import io.restassured.http.Header;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import java.time.LocalDateTime;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -124,7 +125,12 @@ public class AcceptanceTest {
         final ReservationRequest reservationRequest = new ReservationRequest(coachId, interviewDateTime,
                 FORM_ITEM_REQUESTS);
 
-        return post("/api/reservations/", new Header(AUTHORIZATION,
-                BEARER_TYPE + jwtProvider.createToken(String.valueOf(crewId))), reservationRequest);
+        return post("/api/reservations/", generateHeader(crewId), reservationRequest);
     }
+
+    protected Header generateHeader(final Long id) {
+        return new Header(AUTHORIZATION, BEARER_TYPE + jwtProvider.createToken(String.valueOf(id)));
+    }
+
+
 }

--- a/backend/src/test/java/com/woowacourse/ternoko/acceptance/AcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/ternoko/acceptance/AcceptanceTest.java
@@ -112,9 +112,10 @@ public class AcceptanceTest {
     protected ExtractableResponse<Response> createReservation(final Long crewId,
                                                               final Long coachId,
                                                               final LocalDateTime interviewDateTime) {
-        final ReservationRequest reservationRequest = new ReservationRequest(interviewDateTime, FORM_ITEM_REQUESTS);
+        final ReservationRequest reservationRequest = new ReservationRequest(coachId, interviewDateTime,
+                FORM_ITEM_REQUESTS);
 
-        return post("/api/reservations/coaches/" + coachId, new Header(AUTHORIZATION,
+        return post("/api/reservations/", new Header(AUTHORIZATION,
                 BEARER_TYPE + jwtProvider.createToken(String.valueOf(crewId))), reservationRequest);
     }
 }

--- a/backend/src/test/java/com/woowacourse/ternoko/acceptance/AcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/ternoko/acceptance/AcceptanceTest.java
@@ -90,6 +90,15 @@ public class AcceptanceTest {
                 .extract();
     }
 
+    protected ExtractableResponse<Response> patch(final String uri, final Header header) {
+        return RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header(header)
+                .when().patch(uri)
+                .then().log().all()
+                .extract();
+    }
+
     protected ExtractableResponse<Response> patch(final String uri, final Header header, final Object body) {
         return RestAssured.given().log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)

--- a/backend/src/test/java/com/woowacourse/ternoko/acceptance/AcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/ternoko/acceptance/AcceptanceTest.java
@@ -2,7 +2,6 @@ package com.woowacourse.ternoko.acceptance;
 
 import static com.woowacourse.ternoko.config.AuthorizationExtractor.AUTHORIZATION;
 import static com.woowacourse.ternoko.config.AuthorizationExtractor.BEARER_TYPE;
-import static com.woowacourse.ternoko.fixture.ReservationFixture.AFTER_TWO_DAYS;
 import static com.woowacourse.ternoko.fixture.ReservationFixture.FORM_ITEM_REQUESTS;
 
 import com.woowacourse.ternoko.common.JwtProvider;
@@ -110,14 +109,12 @@ public class AcceptanceTest {
                 .extract();
     }
 
-    protected ExtractableResponse<Response> createReservation(final Long coachId,
-                                                              final String crewName,
+    protected ExtractableResponse<Response> createReservation(final Long crewId,
+                                                              final Long coachId,
                                                               final LocalDateTime interviewDateTime) {
-        final ReservationRequest reservationRequest = new ReservationRequest(crewName,
-                interviewDateTime,
-                FORM_ITEM_REQUESTS);
+        final ReservationRequest reservationRequest = new ReservationRequest(interviewDateTime, FORM_ITEM_REQUESTS);
 
         return post("/api/reservations/coaches/" + coachId, new Header(AUTHORIZATION,
-                BEARER_TYPE + jwtProvider.createToken(String.valueOf(coachId))), reservationRequest);
+                BEARER_TYPE + jwtProvider.createToken(String.valueOf(crewId))), reservationRequest);
     }
 }

--- a/backend/src/test/java/com/woowacourse/ternoko/acceptance/CoachAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/ternoko/acceptance/CoachAcceptanceTest.java
@@ -34,7 +34,6 @@ public class CoachAcceptanceTest extends AcceptanceTest {
     @Test
     @DisplayName("코치 - 면담 예약 내역 목록을 조회한다.")
     void findAllByCoaches() {
-        // :todo 현재는 코치 값으로 accessToken 발급 중. 추후 크루 값으로 변경해야 함.
         // given
         put("/api/coaches/" + COACH4.getId() + "/calendar/times", MONTHS_REQUEST);
         createReservation(CREW1.getId(), COACH4.getId(), LocalDateTime.of(NOW_PLUS_2_DAYS, FIRST_TIME));

--- a/backend/src/test/java/com/woowacourse/ternoko/acceptance/CoachAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/ternoko/acceptance/CoachAcceptanceTest.java
@@ -1,7 +1,5 @@
 package com.woowacourse.ternoko.acceptance;
 
-import static com.woowacourse.ternoko.config.AuthorizationExtractor.AUTHORIZATION;
-import static com.woowacourse.ternoko.config.AuthorizationExtractor.BEARER_TYPE;
 import static com.woowacourse.ternoko.fixture.CoachAvailableTimeFixture.FIRST_TIME;
 import static com.woowacourse.ternoko.fixture.CoachAvailableTimeFixture.MONTHS_REQUEST;
 import static com.woowacourse.ternoko.fixture.CoachAvailableTimeFixture.MONTH_REQUEST;
@@ -16,7 +14,6 @@ import static com.woowacourse.ternoko.fixture.MemberFixture.CREW1;
 import static com.woowacourse.ternoko.fixture.MemberFixture.CREW2;
 import static com.woowacourse.ternoko.fixture.MemberFixture.CREW3;
 import static com.woowacourse.ternoko.fixture.MemberFixture.CREW4;
-import static com.woowacourse.ternoko.fixture.ReservationFixture.AFTER_TWO_DAYS;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.woowacourse.ternoko.dto.ScheduleResponse;
@@ -45,7 +42,7 @@ public class CoachAcceptanceTest extends AcceptanceTest {
         final ExtractableResponse<Response> response = RestAssured.given().log().all()
                 .queryParam("year", NOW.getYear())
                 .queryParam("month", NOW.getMonthValue())
-                .header(AUTHORIZATION, BEARER_TYPE + jwtProvider.createToken(String.valueOf(COACH4.getId())))
+                .header(generateHeader(COACH4.getId()))
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .when().get("/api/coaches/" + COACH4.getId() + "/schedules")
                 .then().log().all()
@@ -89,7 +86,7 @@ public class CoachAcceptanceTest extends AcceptanceTest {
         final ExtractableResponse<Response> response = RestAssured.given().log().all()
                 .queryParam("year", NOW.getYear())
                 .queryParam("month", NOW.getMonthValue())
-                .header(AUTHORIZATION, BEARER_TYPE + jwtProvider.createToken(String.valueOf(COACH3.getId())))
+                .header(generateHeader(COACH3.getId()))
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .when().get("/api/coaches/" + COACH3.getId() + "/schedules")
                 .then().log().all()

--- a/backend/src/test/java/com/woowacourse/ternoko/acceptance/CoachAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/ternoko/acceptance/CoachAcceptanceTest.java
@@ -10,15 +10,16 @@ import static com.woowacourse.ternoko.fixture.CoachAvailableTimeFixture.NOW_PLUS
 import static com.woowacourse.ternoko.fixture.CoachAvailableTimeFixture.NOW_PLUS_3_DAYS;
 import static com.woowacourse.ternoko.fixture.CoachAvailableTimeFixture.SECOND_TIME;
 import static com.woowacourse.ternoko.fixture.CoachAvailableTimeFixture.THIRD_TIME;
-import static com.woowacourse.ternoko.fixture.MemberFixture.COACH1;
 import static com.woowacourse.ternoko.fixture.MemberFixture.COACH3;
 import static com.woowacourse.ternoko.fixture.MemberFixture.COACH4;
+import static com.woowacourse.ternoko.fixture.MemberFixture.CREW1;
+import static com.woowacourse.ternoko.fixture.MemberFixture.CREW2;
+import static com.woowacourse.ternoko.fixture.MemberFixture.CREW3;
+import static com.woowacourse.ternoko.fixture.MemberFixture.CREW4;
 import static com.woowacourse.ternoko.fixture.ReservationFixture.AFTER_TWO_DAYS;
-import static com.woowacourse.ternoko.fixture.ReservationFixture.FORM_ITEM_REQUESTS;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.woowacourse.ternoko.dto.ScheduleResponse;
-import com.woowacourse.ternoko.dto.request.ReservationRequest;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
@@ -36,10 +37,10 @@ public class CoachAcceptanceTest extends AcceptanceTest {
         // :todo 현재는 코치 값으로 accessToken 발급 중. 추후 크루 값으로 변경해야 함.
         // given
         put("/api/coaches/" + COACH4.getId() + "/calendar/times", MONTHS_REQUEST);
-        createReservation(COACH4.getId(), "애쉬", LocalDateTime.of(NOW_PLUS_2_DAYS, FIRST_TIME));
-        createReservation(COACH4.getId(), "바니", LocalDateTime.of(NOW_PLUS_2_DAYS, SECOND_TIME));
-        createReservation(COACH4.getId(), "앤지", LocalDateTime.of(NOW_PLUS_2_DAYS, THIRD_TIME));
-        createReservation(COACH4.getId(), "열음", LocalDateTime.of(NOW_PLUS_3_DAYS, FIRST_TIME));
+        createReservation(CREW1.getId(), COACH4.getId(), LocalDateTime.of(NOW_PLUS_2_DAYS, FIRST_TIME));
+        createReservation(CREW2.getId(), COACH4.getId(), LocalDateTime.of(NOW_PLUS_2_DAYS, SECOND_TIME));
+        createReservation(CREW3.getId(), COACH4.getId(), LocalDateTime.of(NOW_PLUS_2_DAYS, THIRD_TIME));
+        createReservation(CREW4.getId(), COACH4.getId(), LocalDateTime.of(NOW_PLUS_3_DAYS, FIRST_TIME));
 
         // when
         final ExtractableResponse<Response> response = RestAssured.given().log().all()
@@ -83,17 +84,13 @@ public class CoachAcceptanceTest extends AcceptanceTest {
     void findAllByCoach() {
         // given
         put("/api/coaches/" + COACH3.getId() + "/calendar/times", MONTHS_REQUEST);
-
-        final ReservationRequest reservationRequest = new ReservationRequest("바니",
-                LocalDateTime.of(NOW_PLUS_2_DAYS, SECOND_TIME),
-                FORM_ITEM_REQUESTS);
-        post("/api/reservations/coaches/" + COACH3.getId(), reservationRequest);
+        createReservation(CREW1.getId(), COACH3.getId(), LocalDateTime.of(NOW_PLUS_2_DAYS, SECOND_TIME));
 
         // when
         final ExtractableResponse<Response> response = RestAssured.given().log().all()
                 .queryParam("year", NOW.getYear())
                 .queryParam("month", NOW.getMonthValue())
-                .header(AUTHORIZATION, BEARER_TYPE + jwtProvider.createToken(String.valueOf(COACH1.getId())))
+                .header(AUTHORIZATION, BEARER_TYPE + jwtProvider.createToken(String.valueOf(COACH3.getId())))
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .when().get("/api/coaches/" + COACH3.getId() + "/schedules")
                 .then().log().all()

--- a/backend/src/test/java/com/woowacourse/ternoko/acceptance/MemberAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/ternoko/acceptance/MemberAcceptanceTest.java
@@ -1,66 +1,49 @@
 package com.woowacourse.ternoko.acceptance;
 
-import static com.woowacourse.ternoko.config.AuthorizationExtractor.AUTHORIZATION;
-import static com.woowacourse.ternoko.config.AuthorizationExtractor.BEARER_TYPE;
 import static com.woowacourse.ternoko.fixture.CoachAvailableTimeFixture.MONTH_REQUEST;
 import static com.woowacourse.ternoko.fixture.CoachAvailableTimeFixture.NOW;
 import static com.woowacourse.ternoko.fixture.MemberFixture.COACH3;
 import static com.woowacourse.ternoko.fixture.MemberFixture.CREW1;
-import static com.woowacourse.ternoko.fixture.MemberFixture.TIME2;
-import static com.woowacourse.ternoko.fixture.MemberFixture.TIME3;
-import static com.woowacourse.ternoko.fixture.MemberFixture.TIME4;
 import static org.assertj.core.api.Assertions.assertThat;
-
-import java.time.LocalDateTime;
-import java.util.List;
-
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
 
 import com.woowacourse.ternoko.dto.AvailableDateTimesResponse;
 import com.woowacourse.ternoko.dto.CoachesResponse;
-import com.woowacourse.ternoko.dto.request.AvailableDateTimeRequest;
-import com.woowacourse.ternoko.dto.request.AvailableDateTimesRequest;
-
 import io.restassured.http.Header;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 
 class MemberAcceptanceTest extends AcceptanceTest {
 
-	@Test
-	@DisplayName("코치 목록을 조회한다.")
-	void find() {
-		//given
-		final Header header = new Header(AUTHORIZATION,
-			BEARER_TYPE + jwtProvider.createToken(String.valueOf(CREW1.getId())));
+    @Test
+    @DisplayName("코치 목록을 조회한다.")
+    void find() {
+        // given & when
+        final ExtractableResponse<Response> response = get("/api/reservations/coaches", generateHeader(CREW1.getId()));
 
-		//when
-		final ExtractableResponse<Response> response = get("/api/reservations/coaches", header);
+        //then
+        final CoachesResponse coachesResponse = response.body().as(CoachesResponse.class);
+        assertThat(coachesResponse.getCoaches()).hasSize(4);
+    }
 
-		//then
-		final CoachesResponse coachesResponse = response.body().as(CoachesResponse.class);
-		assertThat(coachesResponse.getCoaches()).hasSize(4);
-	}
+    @Test
+    @DisplayName("코치의 면담 가능 시간을 조회한다.")
+    void findCalendarTimes() {
+        // given
+        final Header header = generateHeader(CREW1.getId());
+        //TODO: Fixture 리팩토링 후 수정
+        put("/api/coaches/" + COACH3.getId() + "/calendar/times", header, MONTH_REQUEST);
 
-	@Test
-	@DisplayName("코치의 면담 가능 시간을 조회한다.")
-	void findCalendarTimes() {
-		final Header header = new Header(AUTHORIZATION,
-			BEARER_TYPE + jwtProvider.createToken(String.valueOf(CREW1.getId())));
+        final ExtractableResponse<Response> calendarResponse = get(
+                "/api/coaches/" + COACH3.getId() + "/calendar/times?year=" + NOW.getYear() + "&month="
+                        + NOW.getMonthValue(), header);
 
-		// given
-		//TODO: Fixture 리팩토링 후 수정
-		put("/api/coaches/" + COACH3.getId() + "/calendar/times", header, MONTH_REQUEST);
+        // when
+        final AvailableDateTimesResponse response = calendarResponse.body().as(AvailableDateTimesResponse.class);
 
-		final ExtractableResponse<Response> calendarResponse = get(
-			"/api/coaches/" + COACH3.getId() + "/calendar/times?year="+ NOW.getYear()+"&month="+NOW.getMonthValue(), header);
-
-		// when
-		final AvailableDateTimesResponse response = calendarResponse.body().as(AvailableDateTimesResponse.class);
-
-		// then
-		assertThat(response.getCalendarTimes())
-			.hasSize(9);
-	}
+        // then
+        assertThat(response.getCalendarTimes())
+                .hasSize(9);
+    }
 }

--- a/backend/src/test/java/com/woowacourse/ternoko/acceptance/ReservationAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/ternoko/acceptance/ReservationAcceptanceTest.java
@@ -9,6 +9,10 @@ import static com.woowacourse.ternoko.fixture.MemberFixture.COACH1;
 import static com.woowacourse.ternoko.fixture.MemberFixture.COACH2;
 import static com.woowacourse.ternoko.fixture.MemberFixture.COACH3;
 import static com.woowacourse.ternoko.fixture.MemberFixture.COACH4;
+import static com.woowacourse.ternoko.fixture.MemberFixture.CREW1;
+import static com.woowacourse.ternoko.fixture.MemberFixture.CREW2;
+import static com.woowacourse.ternoko.fixture.MemberFixture.CREW3;
+import static com.woowacourse.ternoko.fixture.MemberFixture.CREW4;
 import static com.woowacourse.ternoko.fixture.ReservationFixture.INTERVIEW_TIME;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -31,8 +35,7 @@ class ReservationAcceptanceTest extends AcceptanceTest {
         // given
         put("/api/coaches/" + COACH3.getId() + "/calendar/times", MONTHS_REQUEST);
         // when
-        final ExtractableResponse<Response> response = createReservation(COACH3.getId(),
-                "애쉬",
+        final ExtractableResponse<Response> response = createReservation(CREW1.getId(), COACH3.getId(),
                 LocalDateTime.of(NOW_PLUS_2_DAYS, FIRST_TIME));
 
         //then
@@ -45,8 +48,7 @@ class ReservationAcceptanceTest extends AcceptanceTest {
     void create_WhenInvalidAvailableDateTime() {
         // given
         // when
-        final ExtractableResponse<Response> response = createReservation(COACH3.getId(),
-                "애쉬",
+        final ExtractableResponse<Response> response = createReservation(CREW1.getId(), COACH3.getId(),
                 LocalDateTime.of(NOW_PLUS_2_DAYS, FIRST_TIME));
 
         //then
@@ -60,8 +62,7 @@ class ReservationAcceptanceTest extends AcceptanceTest {
         final Header header = new Header(AUTHORIZATION,
                 BEARER_TYPE + jwtProvider.createToken(String.valueOf(COACH3.getId())));
         put("/api/coaches/" + COACH3.getId() + "/calendar/times", header, MONTHS_REQUEST);
-        final ExtractableResponse<Response> createdResponse = createReservation(COACH3.getId(),
-                "수달",
+        final ExtractableResponse<Response> createdResponse = createReservation(CREW1.getId(), COACH3.getId(),
                 LocalDateTime.of(NOW_PLUS_2_DAYS, FIRST_TIME));
 
         // when
@@ -88,10 +89,10 @@ class ReservationAcceptanceTest extends AcceptanceTest {
         put("/api/coaches/" + COACH3.getId() + "/calendar/times", MONTHS_REQUEST);
         put("/api/coaches/" + COACH4.getId() + "/calendar/times", MONTHS_REQUEST);
 
-        createReservation(COACH1.getId(), "애쉬", LocalDateTime.of(NOW_PLUS_2_DAYS, FIRST_TIME));
-        createReservation(COACH2.getId(), "바니", LocalDateTime.of(NOW_PLUS_2_DAYS, FIRST_TIME));
-        createReservation(COACH3.getId(), "앤지", LocalDateTime.of(NOW_PLUS_2_DAYS, FIRST_TIME));
-        createReservation(COACH4.getId(), "열음", LocalDateTime.of(NOW_PLUS_2_DAYS, FIRST_TIME));
+        createReservation(CREW1.getId(), COACH1.getId(), LocalDateTime.of(NOW_PLUS_2_DAYS, FIRST_TIME));
+        createReservation(CREW2.getId(), COACH2.getId(), LocalDateTime.of(NOW_PLUS_2_DAYS, FIRST_TIME));
+        createReservation(CREW3.getId(), COACH3.getId(), LocalDateTime.of(NOW_PLUS_2_DAYS, FIRST_TIME));
+        createReservation(CREW4.getId(), COACH4.getId(), LocalDateTime.of(NOW_PLUS_2_DAYS, FIRST_TIME));
 
         // when
         final ExtractableResponse<Response> response = get("/api/reservations");

--- a/backend/src/test/java/com/woowacourse/ternoko/acceptance/ReservationAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/ternoko/acceptance/ReservationAcceptanceTest.java
@@ -1,7 +1,5 @@
 package com.woowacourse.ternoko.acceptance;
 
-import static com.woowacourse.ternoko.config.AuthorizationExtractor.AUTHORIZATION;
-import static com.woowacourse.ternoko.config.AuthorizationExtractor.BEARER_TYPE;
 import static com.woowacourse.ternoko.fixture.CoachAvailableTimeFixture.FIRST_TIME;
 import static com.woowacourse.ternoko.fixture.CoachAvailableTimeFixture.MONTHS_REQUEST;
 import static com.woowacourse.ternoko.fixture.CoachAvailableTimeFixture.NOW_PLUS_2_DAYS;
@@ -49,8 +47,7 @@ class ReservationAcceptanceTest extends AcceptanceTest {
     @Test
     @DisplayName("선택한 일시가 코치의 가능한 시간이 아니라면 면담을 생성할 때 예외가 발생한다.")
     void create_WhenInvalidAvailableDateTime() {
-        // given
-        // when
+        // given & when
         final ExtractableResponse<Response> response = createReservation(CREW1.getId(), COACH3.getId(),
                 LocalDateTime.of(NOW_PLUS_2_DAYS, FIRST_TIME));
 
@@ -62,8 +59,7 @@ class ReservationAcceptanceTest extends AcceptanceTest {
     @DisplayName("면담 예약 상세 내역을 조회한다.")
     void findReservationById() {
         // given
-        final Header header = new Header(AUTHORIZATION,
-                BEARER_TYPE + jwtProvider.createToken(String.valueOf(COACH3.getId())));
+        final Header header = generateHeader(COACH3.getId());
         put("/api/coaches/" + COACH3.getId() + "/calendar/times", header, MONTHS_REQUEST);
         final ExtractableResponse<Response> createdResponse = createReservation(CREW1.getId(), COACH3.getId(),
                 LocalDateTime.of(NOW_PLUS_2_DAYS, FIRST_TIME));
@@ -115,14 +111,14 @@ class ReservationAcceptanceTest extends AcceptanceTest {
         final ExtractableResponse<Response> response = createReservation(CREW1.getId(), COACH3.getId(),
                 LocalDateTime.of(NOW_PLUS_2_DAYS, FIRST_TIME));
 
-        String redirectURI = response.header("Location");
-        char reservationId = redirectURI.charAt(redirectURI.length() - 1);
+        final String redirectURI = response.header("Location");
+        final char reservationId = redirectURI.charAt(redirectURI.length() - 1);
 
         // when
         final ReservationRequest updateRequest = new ReservationRequest(COACH3.getId(),
                 LocalDateTime.of(NOW_PLUS_2_DAYS, SECOND_TIME), FORM_ITEM_REQUESTS);
         ExtractableResponse<Response> updateResponse = put("/api/reservations/" + reservationId,
-                new Header(AUTHORIZATION, BEARER_TYPE + jwtProvider.createToken(String.valueOf(CREW1.getId()))),
+                generateHeader(CREW1.getId()),
                 updateRequest);
 
         //then
@@ -137,12 +133,12 @@ class ReservationAcceptanceTest extends AcceptanceTest {
         final ExtractableResponse<Response> response = createReservation(CREW1.getId(), COACH3.getId(),
                 LocalDateTime.of(NOW_PLUS_2_DAYS, FIRST_TIME));
 
-        String redirectURI = response.header("Location");
-        char reservationId = redirectURI.charAt(redirectURI.length() - 1);
+        final String redirectURI = response.header("Location");
+        final char reservationId = redirectURI.charAt(redirectURI.length() - 1);
 
         // when
-        ExtractableResponse<Response> deleteResponse = delete("/api/reservations/" + reservationId,
-                new Header(AUTHORIZATION, BEARER_TYPE + jwtProvider.createToken(String.valueOf(CREW1.getId()))));
+        final ExtractableResponse<Response> deleteResponse = delete("/api/reservations/" + reservationId,
+                generateHeader(CREW1.getId()));
 
         //then
         assertThat(deleteResponse.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
@@ -156,12 +152,12 @@ class ReservationAcceptanceTest extends AcceptanceTest {
         final ExtractableResponse<Response> response = createReservation(CREW1.getId(), COACH3.getId(),
                 LocalDateTime.of(NOW_PLUS_2_DAYS, FIRST_TIME));
 
-        String redirectURI = response.header("Location");
-        char reservationId = redirectURI.charAt(redirectURI.length() - 1);
+        final String redirectURI = response.header("Location");
+        final char reservationId = redirectURI.charAt(redirectURI.length() - 1);
 
         // when
-        ExtractableResponse<Response> cancelResponse = patch("/api/reservations/" + reservationId,
-                new Header(AUTHORIZATION, BEARER_TYPE + jwtProvider.createToken(String.valueOf(COACH3.getId()))));
+        final ExtractableResponse<Response> cancelResponse = patch("/api/reservations/" + reservationId,
+                generateHeader(COACH3.getId()));
 
         //then
         assertThat(cancelResponse.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());

--- a/backend/src/test/java/com/woowacourse/ternoko/acceptance/ReservationAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/ternoko/acceptance/ReservationAcceptanceTest.java
@@ -147,4 +147,23 @@ class ReservationAcceptanceTest extends AcceptanceTest {
         //then
         assertThat(deleteResponse.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
     }
+
+    @Test
+    @DisplayName("코치가 면담 예약을 취소한다.")
+    void cancelReservation() {
+        // given
+        put("/api/coaches/" + COACH3.getId() + "/calendar/times", MONTHS_REQUEST);
+        final ExtractableResponse<Response> response = createReservation(CREW1.getId(), COACH3.getId(),
+                LocalDateTime.of(NOW_PLUS_2_DAYS, FIRST_TIME));
+
+        String redirectURI = response.header("Location");
+        char reservationId = redirectURI.charAt(redirectURI.length() - 1);
+
+        // when
+        ExtractableResponse<Response> cancelResponse = patch("/api/reservations/" + reservationId,
+                new Header(AUTHORIZATION, BEARER_TYPE + jwtProvider.createToken(String.valueOf(COACH3.getId()))));
+
+        //then
+        assertThat(cancelResponse.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
+    }
 }

--- a/backend/src/test/java/com/woowacourse/ternoko/acceptance/ReservationAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/ternoko/acceptance/ReservationAcceptanceTest.java
@@ -128,4 +128,23 @@ class ReservationAcceptanceTest extends AcceptanceTest {
         //then
         assertThat(updateResponse.statusCode()).isEqualTo(HttpStatus.OK.value());
     }
+
+    @Test
+    @DisplayName("크루가 면담 예약을 삭제한다.")
+    void deleteReservation() {
+        // given
+        put("/api/coaches/" + COACH3.getId() + "/calendar/times", MONTHS_REQUEST);
+        final ExtractableResponse<Response> response = createReservation(CREW1.getId(), COACH3.getId(),
+                LocalDateTime.of(NOW_PLUS_2_DAYS, FIRST_TIME));
+
+        String redirectURI = response.header("Location");
+        char reservationId = redirectURI.charAt(redirectURI.length() - 1);
+
+        // when
+        ExtractableResponse<Response> deleteResponse = delete("/api/reservations/" + reservationId,
+                new Header(AUTHORIZATION, BEARER_TYPE + jwtProvider.createToken(String.valueOf(CREW1.getId()))));
+
+        //then
+        assertThat(deleteResponse.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
+    }
 }

--- a/backend/src/test/java/com/woowacourse/ternoko/api/CoachControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/ternoko/api/CoachControllerTest.java
@@ -20,7 +20,7 @@ public class CoachControllerTest extends ControllerTest {
     void findAllByCoach() throws Exception {
         // given
         createCalendarTimes(COACH1.getId());
-        createReservations(CREW1.getId(), COACH1.getId());
+        createReservations(CREW1.getId());
 
         // when, then
         mockMvc.perform(MockMvcRequestBuilders

--- a/backend/src/test/java/com/woowacourse/ternoko/api/CoachControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/ternoko/api/CoachControllerTest.java
@@ -3,6 +3,7 @@ package com.woowacourse.ternoko.api;
 import static com.woowacourse.ternoko.config.AuthorizationExtractor.AUTHORIZATION;
 import static com.woowacourse.ternoko.config.AuthorizationExtractor.BEARER_TYPE;
 import static com.woowacourse.ternoko.fixture.MemberFixture.COACH1;
+import static com.woowacourse.ternoko.fixture.MemberFixture.CREW1;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -19,7 +20,7 @@ public class CoachControllerTest extends ControllerTest {
     void findAllByCoach() throws Exception {
         // given
         createCalendarTimes(COACH1.getId());
-        createReservations(COACH1.getId());
+        createReservations(CREW1.getId(), COACH1.getId());
 
         // when, then
         mockMvc.perform(MockMvcRequestBuilders

--- a/backend/src/test/java/com/woowacourse/ternoko/api/ControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/ternoko/api/ControllerTest.java
@@ -20,9 +20,9 @@ public class ControllerTest extends RestDocsTestSupport {
                 .andExpect(status().isOk());
     }
 
-    public void createReservations(final Long crewId, final Long coachId) throws Exception {
+    public void createReservations(final Long crewId) throws Exception {
         mockMvc.perform(MockMvcRequestBuilders
-                        .post("/api/reservations/coaches/{coachId}", coachId)
+                        .post("/api/reservations")
                         .contentType(MediaType.APPLICATION_JSON)
                         .header(AUTHORIZATION, BEARER_TYPE + jwtProvider.createToken(String.valueOf(crewId)))
                         .characterEncoding("utf-8")
@@ -30,7 +30,7 @@ public class ControllerTest extends RestDocsTestSupport {
                 .andExpect(status().isCreated());
 
         mockMvc.perform(MockMvcRequestBuilders
-                        .post("/api/reservations/coaches/{coachId}", coachId)
+                        .post("/api/reservations")
                         .contentType(MediaType.APPLICATION_JSON)
                         .header(AUTHORIZATION, BEARER_TYPE + jwtProvider.createToken(String.valueOf(crewId)))
                         .characterEncoding("utf-8")

--- a/backend/src/test/java/com/woowacourse/ternoko/api/ControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/ternoko/api/ControllerTest.java
@@ -20,11 +20,11 @@ public class ControllerTest extends RestDocsTestSupport {
                 .andExpect(status().isOk());
     }
 
-    public void createReservations(final Long coachId) throws Exception {
+    public void createReservations(final Long crewId, final Long coachId) throws Exception {
         mockMvc.perform(MockMvcRequestBuilders
                         .post("/api/reservations/coaches/{coachId}", coachId)
                         .contentType(MediaType.APPLICATION_JSON)
-                        .header(AUTHORIZATION, BEARER_TYPE + jwtProvider.createToken(String.valueOf(coachId)))
+                        .header(AUTHORIZATION, BEARER_TYPE + jwtProvider.createToken(String.valueOf(crewId)))
                         .characterEncoding("utf-8")
                         .content(readJson("/json/reservations/create-reservation1.json")))
                 .andExpect(status().isCreated());
@@ -32,7 +32,7 @@ public class ControllerTest extends RestDocsTestSupport {
         mockMvc.perform(MockMvcRequestBuilders
                         .post("/api/reservations/coaches/{coachId}", coachId)
                         .contentType(MediaType.APPLICATION_JSON)
-                        .header(AUTHORIZATION, BEARER_TYPE + jwtProvider.createToken(String.valueOf(coachId)))
+                        .header(AUTHORIZATION, BEARER_TYPE + jwtProvider.createToken(String.valueOf(crewId)))
                         .characterEncoding("utf-8")
                         .content(readJson("/json/reservations/create-reservation2.json")))
                 .andExpect(status().isCreated());

--- a/backend/src/test/java/com/woowacourse/ternoko/api/ReservationControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/ternoko/api/ReservationControllerTest.java
@@ -22,7 +22,7 @@ public class ReservationControllerTest extends ControllerTest {
     void create() throws Exception {
         createCalendarTimes(COACH1.getId());
         mockMvc.perform(MockMvcRequestBuilders
-                        .post("/api/reservations/coaches/{coachId}", COACH1.getId())
+                        .post("/api/reservations")
                         .contentType(MediaType.APPLICATION_JSON)
                         .header(AUTHORIZATION, BEARER_TYPE + jwtProvider.createToken(String.valueOf(CREW1.getId())))
                         .characterEncoding("utf-8")
@@ -30,7 +30,7 @@ public class ReservationControllerTest extends ControllerTest {
                 .andExpect(status().isCreated())
                 .andDo(restDocs.document(
                         requestFields(
-                                fieldWithPath("crewNickname").type(JsonFieldType.STRING).description("크루 닉네임"),
+                                fieldWithPath("coachId").type(JsonFieldType.NUMBER).description("코치 ID"),
                                 fieldWithPath("interviewDatetime").type(JsonFieldType.STRING)
                                         .description("인터뷰 시간"),
                                 fieldWithPath("interviewQuestions.[].question").description("면담질문1"),
@@ -43,7 +43,7 @@ public class ReservationControllerTest extends ControllerTest {
     void findReservationById() throws Exception {
         // given
         createCalendarTimes(COACH1.getId());
-        createReservations(CREW1.getId(),COACH1.getId());
+        createReservations(CREW1.getId());
 
         // when, then
         mockMvc.perform(MockMvcRequestBuilders
@@ -58,7 +58,7 @@ public class ReservationControllerTest extends ControllerTest {
     void findAll() throws Exception {
         // given
         createCalendarTimes(COACH1.getId());
-        createReservations(CREW1.getId(),COACH1.getId());
+        createReservations(CREW1.getId());
 
         // when, then
         mockMvc.perform(MockMvcRequestBuilders

--- a/backend/src/test/java/com/woowacourse/ternoko/api/ReservationControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/ternoko/api/ReservationControllerTest.java
@@ -3,6 +3,7 @@ package com.woowacourse.ternoko.api;
 import static com.woowacourse.ternoko.config.AuthorizationExtractor.AUTHORIZATION;
 import static com.woowacourse.ternoko.config.AuthorizationExtractor.BEARER_TYPE;
 import static com.woowacourse.ternoko.fixture.MemberFixture.COACH1;
+import static com.woowacourse.ternoko.fixture.MemberFixture.CREW1;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
@@ -23,7 +24,7 @@ public class ReservationControllerTest extends ControllerTest {
         mockMvc.perform(MockMvcRequestBuilders
                         .post("/api/reservations/coaches/{coachId}", COACH1.getId())
                         .contentType(MediaType.APPLICATION_JSON)
-                        .header(AUTHORIZATION, BEARER_TYPE + jwtProvider.createToken(String.valueOf(COACH1.getId())))
+                        .header(AUTHORIZATION, BEARER_TYPE + jwtProvider.createToken(String.valueOf(CREW1.getId())))
                         .characterEncoding("utf-8")
                         .content(readJson("/json/reservations/create-reservation1.json")))
                 .andExpect(status().isCreated())
@@ -42,12 +43,12 @@ public class ReservationControllerTest extends ControllerTest {
     void findReservationById() throws Exception {
         // given
         createCalendarTimes(COACH1.getId());
-        createReservations(COACH1.getId());
+        createReservations(CREW1.getId(),COACH1.getId());
 
         // when, then
         mockMvc.perform(MockMvcRequestBuilders
                         .get("/api/reservations/{reservationId}", 1)
-                        .header(AUTHORIZATION, BEARER_TYPE + jwtProvider.createToken(String.valueOf(COACH1.getId()))))
+                        .header(AUTHORIZATION, BEARER_TYPE + jwtProvider.createToken(String.valueOf(CREW1.getId()))))
                 .andExpect(status().isOk())
                 .andDo(restDocs.document());
     }
@@ -57,7 +58,7 @@ public class ReservationControllerTest extends ControllerTest {
     void findAll() throws Exception {
         // given
         createCalendarTimes(COACH1.getId());
-        createReservations(COACH1.getId());
+        createReservations(CREW1.getId(),COACH1.getId());
 
         // when, then
         mockMvc.perform(MockMvcRequestBuilders

--- a/backend/src/test/java/com/woowacourse/ternoko/fixture/CoachAvailableTimeFixture.java
+++ b/backend/src/test/java/com/woowacourse/ternoko/fixture/CoachAvailableTimeFixture.java
@@ -24,6 +24,16 @@ public class CoachAvailableTimeFixture {
     public static final LocalTime SECOND_TIME = LocalTime.of(14, 0);
     public static final LocalTime THIRD_TIME = LocalTime.of(16, 0);
 
+    public static final AvailableDateTimeRequest PAST_TIME_REQUEST = new AvailableDateTimeRequest(
+            LocalDate.now().getYear(),
+            LocalDate.now().getMonthValue(),
+            List.of(LocalDateTime.of(LocalDate.now().minusDays(2), FIRST_TIME),
+                    LocalDateTime.of(LocalDate.now().minusDays(2), SECOND_TIME),
+                    LocalDateTime.of(LocalDate.now().minusDays(2), THIRD_TIME),
+                    LocalDateTime.of(LocalDate.now(), FIRST_TIME),
+                    LocalDateTime.of(LocalDate.now(), SECOND_TIME),
+                    LocalDateTime.of(LocalDate.now(), THIRD_TIME)));
+
     public static final AvailableDateTimeRequest PAST_TIME_RESPONSE = new AvailableDateTimeRequest(
             LocalDate.now().getYear(),
             LocalDate.now().getMonthValue(),

--- a/backend/src/test/java/com/woowacourse/ternoko/fixture/MemberFixture.java
+++ b/backend/src/test/java/com/woowacourse/ternoko/fixture/MemberFixture.java
@@ -9,13 +9,17 @@ import java.util.List;
 
 public class MemberFixture {
 
-    public static final Member COACH1 = new Coach(1L, "이름", "준", "test1@woowahan.com", "imageUr", "안녕하세요.");
-    public static final Member COACH2 = new Coach(2L, "이름", "브리", "test2@woowahan.com", "imageUrl", "안녕하세요.");
-    public static final Member COACH3 = new Coach(3L, "이름", "토미", "test3@woowahan.com", "imageUrl", "안녕하세요.");
-    public static final Member COACH4 = new Coach(4L, "이름", "네오", "test4@woowahan.com", "imageUrl", "안녕하세요.");
-    public static final Member CREW1 = new Crew(5L, "허수진", "수달", "test5@woowahan.com", "imageUrl");
-    public static final Member CREW2 = new Crew(6L, "손수민", "앤지", "test6@email.com", "imageUrl");
-    public static final Member CREW3 = new Crew(7L, "김동호", "애쉬", "test7@email.com", "imageUrl");
+    public static final Member COACH1 = new Coach(1L, "이름", "준", "test1@woowahan.com", "U123456789", "imageUr",
+            "안녕하세요.");
+    public static final Member COACH2 = new Coach(2L, "이름", "브리", "test2@woowahan.com", "U123456789", "imageUrl",
+            "안녕하세요.");
+    public static final Member COACH3 = new Coach(3L, "이름", "토미", "test3@woowahan.com", "U123456789", "imageUrl",
+            "안녕하세요.");
+    public static final Member COACH4 = new Coach(4L, "이름", "네오", "test4@woowahan.com", "U123456789", "imageUrl",
+            "안녕하세요.");
+    public static final Member CREW1 = new Crew(5L, "허수진", "수달", "test5@woowahan.com", "U123456789", "imageUrl");
+    public static final Member CREW2 = new Crew(6L, "손수민", "앤지", "test6@email.com", "U123456789", "imageUrl");
+    public static final Member CREW3 = new Crew(7L, "김동호", "애쉬", "test7@email.com", "U123456789", "imageUrl");
 
     public static final LocalDateTime TIME2 = LocalDateTime.now().plusDays(2);
     public static final LocalDateTime TIME3 = LocalDateTime.now().plusDays(3);

--- a/backend/src/test/java/com/woowacourse/ternoko/fixture/MemberFixture.java
+++ b/backend/src/test/java/com/woowacourse/ternoko/fixture/MemberFixture.java
@@ -20,6 +20,7 @@ public class MemberFixture {
     public static final Member CREW1 = new Crew(5L, "허수진", "수달", "test5@woowahan.com", "U123456789", "imageUrl");
     public static final Member CREW2 = new Crew(6L, "손수민", "앤지", "test6@email.com", "U123456789", "imageUrl");
     public static final Member CREW3 = new Crew(7L, "김동호", "애쉬", "test7@email.com", "U123456789", "imageUrl");
+    public static final Member CREW4 = new Crew(8L, "김상록", "록바", "test8@email.com", "U123456789", "imageUrl");
 
     public static final LocalDateTime TIME2 = LocalDateTime.now().plusDays(2);
     public static final LocalDateTime TIME3 = LocalDateTime.now().plusDays(3);

--- a/backend/src/test/java/com/woowacourse/ternoko/fixture/MemberFixture.java
+++ b/backend/src/test/java/com/woowacourse/ternoko/fixture/MemberFixture.java
@@ -9,18 +9,18 @@ import java.util.List;
 
 public class MemberFixture {
 
-    public static final Member COACH1 = new Coach(1L, "이름", "준", "test1@woowahan.com", "U123456789", "imageUr",
+    public static final Member COACH1 = new Coach(1L, "이름", "준", "test1@woowahan.com", "U1234567891", "imageUr",
             "안녕하세요.");
-    public static final Member COACH2 = new Coach(2L, "이름", "브리", "test2@woowahan.com", "U123456789", "imageUrl",
+    public static final Member COACH2 = new Coach(2L, "이름", "브리", "test2@woowahan.com", "U1234567892", "imageUrl",
             "안녕하세요.");
-    public static final Member COACH3 = new Coach(3L, "이름", "토미", "test3@woowahan.com", "U123456789", "imageUrl",
+    public static final Member COACH3 = new Coach(3L, "이름", "토미", "test3@woowahan.com", "U1234567893", "imageUrl",
             "안녕하세요.");
-    public static final Member COACH4 = new Coach(4L, "이름", "네오", "test4@woowahan.com", "U123456789", "imageUrl",
+    public static final Member COACH4 = new Coach(4L, "이름", "네오", "test4@woowahan.com", "U1234567894", "imageUrl",
             "안녕하세요.");
-    public static final Member CREW1 = new Crew(5L, "허수진", "수달", "test5@woowahan.com", "U123456789", "imageUrl");
-    public static final Member CREW2 = new Crew(6L, "손수민", "앤지", "test6@email.com", "U123456789", "imageUrl");
-    public static final Member CREW3 = new Crew(7L, "김동호", "애쉬", "test7@email.com", "U123456789", "imageUrl");
-    public static final Member CREW4 = new Crew(8L, "김상록", "록바", "test8@email.com", "U123456789", "imageUrl");
+    public static final Member CREW1 = new Crew(5L, "허수진", "수달", "test5@woowahan.com", "U1234567895", "imageUrl");
+    public static final Member CREW2 = new Crew(6L, "손수민", "앤지", "test6@email.com", "U1234567896", "imageUrl");
+    public static final Member CREW3 = new Crew(7L, "김동호", "애쉬", "test7@email.com", "U1234567897", "imageUrl");
+    public static final Member CREW4 = new Crew(8L, "김상록", "록바", "test8@email.com", "U1234567898", "imageUrl");
 
     public static final LocalDateTime TIME2 = LocalDateTime.now().plusDays(2);
     public static final LocalDateTime TIME3 = LocalDateTime.now().plusDays(3);

--- a/backend/src/test/java/com/woowacourse/ternoko/fixture/ReservationFixture.java
+++ b/backend/src/test/java/com/woowacourse/ternoko/fixture/ReservationFixture.java
@@ -22,23 +22,18 @@ public class ReservationFixture {
             new FormItem("고정질문2", "답변2"),
             new FormItem("고정질문3", "답변3"));
 
-    public static final ReservationRequest RESERVATION_REQUEST1 = new ReservationRequest("바니",
-            AFTER_TWO_DAYS,
+    public static final ReservationRequest RESERVATION_REQUEST1 = new ReservationRequest(AFTER_TWO_DAYS,
             FORM_ITEM_REQUESTS);
 
-    public static final ReservationRequest RESERVATION_REQUEST2 = new ReservationRequest("열음",
-            AFTER_TWO_DAYS,
+    public static final ReservationRequest RESERVATION_REQUEST2 = new ReservationRequest(AFTER_TWO_DAYS,
             FORM_ITEM_REQUESTS);
 
-    public static final ReservationRequest RESERVATION_REQUEST3 = new ReservationRequest("앤지",
-            AFTER_TWO_DAYS,
+    public static final ReservationRequest RESERVATION_REQUEST3 = new ReservationRequest(AFTER_TWO_DAYS,
             FORM_ITEM_REQUESTS);
 
-    public static final ReservationRequest RESERVATION_REQUEST4 = new ReservationRequest("애쉬",
-            AFTER_TWO_DAYS,
+    public static final ReservationRequest RESERVATION_REQUEST4 = new ReservationRequest(AFTER_TWO_DAYS,
             FORM_ITEM_REQUESTS);
 
-    public static final ReservationRequest RESERVATION_REQUEST5 = new ReservationRequest("수달",
-            AFTER_TWO_DAYS,
+    public static final ReservationRequest RESERVATION_REQUEST5 = new ReservationRequest(AFTER_TWO_DAYS,
             FORM_ITEM_REQUESTS);
 }

--- a/backend/src/test/java/com/woowacourse/ternoko/fixture/ReservationFixture.java
+++ b/backend/src/test/java/com/woowacourse/ternoko/fixture/ReservationFixture.java
@@ -20,6 +20,10 @@ public class ReservationFixture {
             new FormItemRequest("고정질문2", "답변2"),
             new FormItemRequest("고정질문3", "답변3"));
 
+    public static final List<FormItemRequest> FORM_ITEM_UPDATE_REQUESTS = List.of(new FormItemRequest("수정질문1", "수정답변1"),
+            new FormItemRequest("수정질문2", "수정답변2"),
+            new FormItemRequest("수정질문3", "수정답변3"));
+
     public static final List<FormItem> FORM_ITEMS = List.of(new FormItem("고정질문1", "답변1"),
             new FormItem("고정질문2", "답변2"),
             new FormItem("고정질문3", "답변3"));

--- a/backend/src/test/java/com/woowacourse/ternoko/fixture/ReservationFixture.java
+++ b/backend/src/test/java/com/woowacourse/ternoko/fixture/ReservationFixture.java
@@ -1,5 +1,7 @@
 package com.woowacourse.ternoko.fixture;
 
+import static com.woowacourse.ternoko.fixture.MemberFixture.COACH3;
+
 import com.woowacourse.ternoko.domain.FormItem;
 import com.woowacourse.ternoko.dto.request.FormItemRequest;
 import com.woowacourse.ternoko.dto.request.ReservationRequest;
@@ -22,18 +24,14 @@ public class ReservationFixture {
             new FormItem("고정질문2", "답변2"),
             new FormItem("고정질문3", "답변3"));
 
-    public static final ReservationRequest RESERVATION_REQUEST1 = new ReservationRequest(AFTER_TWO_DAYS,
+    public static final ReservationRequest RESERVATION_REQUEST1 = new ReservationRequest(COACH3.getId(), AFTER_TWO_DAYS,
             FORM_ITEM_REQUESTS);
-
-    public static final ReservationRequest RESERVATION_REQUEST2 = new ReservationRequest(AFTER_TWO_DAYS,
+    public static final ReservationRequest RESERVATION_REQUEST2 = new ReservationRequest(COACH3.getId(), AFTER_TWO_DAYS,
             FORM_ITEM_REQUESTS);
-
-    public static final ReservationRequest RESERVATION_REQUEST3 = new ReservationRequest(AFTER_TWO_DAYS,
+    public static final ReservationRequest RESERVATION_REQUEST3 = new ReservationRequest(COACH3.getId(), AFTER_TWO_DAYS,
             FORM_ITEM_REQUESTS);
-
-    public static final ReservationRequest RESERVATION_REQUEST4 = new ReservationRequest(AFTER_TWO_DAYS,
+    public static final ReservationRequest RESERVATION_REQUEST4 = new ReservationRequest(COACH3.getId(), AFTER_TWO_DAYS,
             FORM_ITEM_REQUESTS);
-
-    public static final ReservationRequest RESERVATION_REQUEST5 = new ReservationRequest(AFTER_TWO_DAYS,
+    public static final ReservationRequest RESERVATION_REQUEST5 = new ReservationRequest(COACH3.getId(), AFTER_TWO_DAYS,
             FORM_ITEM_REQUESTS);
 }

--- a/backend/src/test/java/com/woowacourse/ternoko/service/AuthServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/ternoko/service/AuthServiceTest.java
@@ -13,9 +13,6 @@ import com.slack.api.methods.response.openid.connect.OpenIDConnectUserInfoRespon
 import com.woowacourse.ternoko.common.JwtProvider;
 import com.woowacourse.ternoko.domain.Type;
 import com.woowacourse.ternoko.dto.LoginResponse;
-import com.woowacourse.ternoko.repository.CoachRepository;
-import com.woowacourse.ternoko.repository.CrewRepository;
-import com.woowacourse.ternoko.repository.MemberRepository;
 import java.io.IOException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -25,7 +22,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.mock.mockito.SpyBean;
-import org.springframework.test.context.ActiveProfiles;
 
 @ExtendWith(MockitoExtension.class)
 @SpringBootTest
@@ -102,7 +98,7 @@ public class AuthServiceTest {
 
     private void setSlackMockData(String userEmail) throws IOException, SlackApiException {
 
-        OpenIDConnectTokenResponse openIDConnectTokenResponse = new OpenIDConnectTokenResponse();
+        final OpenIDConnectTokenResponse openIDConnectTokenResponse = new OpenIDConnectTokenResponse();
         openIDConnectTokenResponse.setAccessToken("temp_accessToken");
 
         final OpenIDConnectUserInfoResponse userInfoResponse = new OpenIDConnectUserInfoResponse();

--- a/backend/src/test/java/com/woowacourse/ternoko/service/CoachServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/ternoko/service/CoachServiceTest.java
@@ -55,8 +55,9 @@ public class CoachServiceTest {
         final String imageUrl = ".png";
         final String nickname = "도깨비";
         final String introduce = "안녕하세요. 도깨비 입니다.";
+        final String userId = "U123456789";
 
-        final Coach savedCoach = coachRepository.save(new Coach("공유", " share@woowahan.com", imageUrl));
+        final Coach savedCoach = coachRepository.save(new Coach("공유", " share@woowahan.com", userId, imageUrl));
 
         //when
         coachService.partUpdateCrew(savedCoach.getId(), new CoachUpdateRequest(nickname, imageUrl, introduce));

--- a/backend/src/test/java/com/woowacourse/ternoko/service/CoachServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/ternoko/service/CoachServiceTest.java
@@ -111,11 +111,9 @@ public class CoachServiceTest {
     void findAvailableDateTimesByCoachId() {
         // given
         coachService.putAvailableDateTimesByCoachId(COACH3.getId(), MONTHS_REQUEST);
-
         // when
         final List<AvailableDateTime> availableDateTimes = coachService
-                .findAvailableDateTimesByCoachId(COACH3.getId(), NOW_PLUS_1_MONTH.getYear(),
-                        NOW_PLUS_1_MONTH.getMonthValue());
+                .findAvailableDateTimesByCoachId(COACH3.getId(), NOW_PLUS_1_MONTH.getYear(), NOW_PLUS_1_MONTH.getMonthValue());
 
         // then
         assertThat(availableDateTimes.stream()

--- a/backend/src/test/java/com/woowacourse/ternoko/service/CrewServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/ternoko/service/CrewServiceTest.java
@@ -24,7 +24,7 @@ public class CrewServiceTest {
     @DisplayName("slack 회원가입 후 닉네임과 이미지를 입력받아 partUpdate 한다")
     void partUpdateCrew() {
         // given
-        final Crew savedCrew = crewService.save(new Crew("톰크루즈", null, "sudal@gmail.com", null));
+        final Crew savedCrew = crewService.save(new Crew("톰크루즈", null, "sudal@gmail.com", "U123456789", null));
         final String nickname = "매버릭";
         final String imageUrl = "탑건2.png";
 

--- a/backend/src/test/java/com/woowacourse/ternoko/service/ReservationServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/ternoko/service/ReservationServiceTest.java
@@ -207,8 +207,9 @@ class ReservationServiceTest {
                 new ReservationRequest(COACH3.getId(), LocalDateTime.of(NOW_PLUS_2_DAYS, FIRST_TIME),
                         FORM_ITEM_REQUESTS));
         // when
-        Reservation updateReservation = reservationService.update(CREW1.getId(), reservation.getId(),
-                new ReservationRequest(COACH3.getId(), LocalDateTime.of(NOW_PLUS_3_DAYS, SECOND_TIME),
+        final Reservation updateReservation = reservationService.update(CREW1.getId(), reservation.getId(),
+                new ReservationRequest(COACH3.getId(),
+                        LocalDateTime.of(NOW_PLUS_3_DAYS, SECOND_TIME),
                         FORM_ITEM_UPDATE_REQUESTS));
 
         // then

--- a/backend/src/test/java/com/woowacourse/ternoko/service/ReservationServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/ternoko/service/ReservationServiceTest.java
@@ -3,6 +3,7 @@ package com.woowacourse.ternoko.service;
 import static com.woowacourse.ternoko.fixture.CoachAvailableTimeFixture.FIRST_TIME;
 import static com.woowacourse.ternoko.fixture.CoachAvailableTimeFixture.MONTH_REQUEST;
 import static com.woowacourse.ternoko.fixture.CoachAvailableTimeFixture.NOW;
+import static com.woowacourse.ternoko.fixture.CoachAvailableTimeFixture.NOW_MINUS_2_DAYS;
 import static com.woowacourse.ternoko.fixture.CoachAvailableTimeFixture.NOW_PLUS_2_DAYS;
 import static com.woowacourse.ternoko.fixture.CoachAvailableTimeFixture.NOW_PLUS_3_DAYS;
 import static com.woowacourse.ternoko.fixture.CoachAvailableTimeFixture.PAST_REQUEST;
@@ -12,6 +13,10 @@ import static com.woowacourse.ternoko.fixture.MemberFixture.COACH1;
 import static com.woowacourse.ternoko.fixture.MemberFixture.COACH2;
 import static com.woowacourse.ternoko.fixture.MemberFixture.COACH3;
 import static com.woowacourse.ternoko.fixture.MemberFixture.COACH4;
+import static com.woowacourse.ternoko.fixture.MemberFixture.CREW1;
+import static com.woowacourse.ternoko.fixture.MemberFixture.CREW2;
+import static com.woowacourse.ternoko.fixture.MemberFixture.CREW3;
+import static com.woowacourse.ternoko.fixture.MemberFixture.CREW4;
 import static com.woowacourse.ternoko.fixture.ReservationFixture.FORM_ITEM_REQUESTS;
 import static com.woowacourse.ternoko.fixture.ReservationFixture.INTERVIEW_TIME;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -22,6 +27,7 @@ import com.woowacourse.ternoko.common.exception.CoachNotFoundException;
 import com.woowacourse.ternoko.common.exception.ExceptionType;
 import com.woowacourse.ternoko.common.exception.InvalidReservationDateException;
 import com.woowacourse.ternoko.common.exception.ReservationNotFoundException;
+import com.woowacourse.ternoko.domain.Reservation;
 import com.woowacourse.ternoko.dto.ReservationResponse;
 import com.woowacourse.ternoko.dto.ScheduleResponse;
 import com.woowacourse.ternoko.dto.request.ReservationRequest;
@@ -51,15 +57,13 @@ class ReservationServiceTest {
         // given, when
         coachService.putAvailableDateTimesByCoachId(COACH3.getId(), MONTH_REQUEST);
 
-        final Long id = reservationService.create(COACH3.getId(), new ReservationRequest("앤지",
-                LocalDateTime.of(NOW_PLUS_2_DAYS, FIRST_TIME),
-                FORM_ITEM_REQUESTS));
-
-        final ReservationResponse reservationResponse = reservationService.findReservationById(id);
+        final Reservation reservation = reservationService.create(CREW1.getId(), COACH3.getId(),
+                new ReservationRequest(LocalDateTime.of(NOW_PLUS_2_DAYS, FIRST_TIME), FORM_ITEM_REQUESTS));
+        final ReservationResponse reservationResponse = reservationService.findReservationById(reservation.getId());
 
         // then
         assertAll(
-                () -> assertThat(id).isNotNull(),
+                () -> assertThat(reservation.getId()).isNotNull(),
                 () -> assertThat(reservationResponse.getCoachNickname())
                         .isEqualTo(COACH3.getNickname()),
                 () -> assertThat(reservationResponse.getInterviewStartTime())
@@ -78,9 +82,8 @@ class ReservationServiceTest {
     @Test
     @DisplayName("면담 예약 선택 일자가 코치의 가능한 시간이 아닌 경우 예외가 발생한다.")
     void create_WhenInvalidAvailableDateTime() {
-        assertThatThrownBy(() -> reservationService.create(COACH1.getId(), new ReservationRequest("앤지",
-                LocalDateTime.of(NOW_PLUS_2_DAYS, FIRST_TIME),
-                FORM_ITEM_REQUESTS)))
+        assertThatThrownBy(() -> reservationService.create(CREW1.getId(), COACH1.getId(),
+                new ReservationRequest(LocalDateTime.of(NOW_PLUS_2_DAYS, FIRST_TIME), FORM_ITEM_REQUESTS)))
                 .isInstanceOf(InvalidReservationDateException.class)
                 .hasMessage(ExceptionType.INVALID_AVAILABLE_DATE_TIME.getMessage());
     }
@@ -88,9 +91,8 @@ class ReservationServiceTest {
     @Test
     @DisplayName("없는 코치로 예약할 시 예외가 발생한다.")
     void create_coachNotFound() {
-        assertThatThrownBy(() -> reservationService.create(-1L, new ReservationRequest("앤지",
-                LocalDateTime.of(NOW_PLUS_2_DAYS, FIRST_TIME),
-                FORM_ITEM_REQUESTS)))
+        assertThatThrownBy(() -> reservationService.create(CREW1.getId(), -1L,
+                new ReservationRequest(LocalDateTime.of(NOW_PLUS_2_DAYS, FIRST_TIME), FORM_ITEM_REQUESTS)))
                 .isInstanceOf(CoachNotFoundException.class);
     }
 
@@ -109,14 +111,14 @@ class ReservationServiceTest {
         coachService.putAvailableDateTimesByCoachId(COACH2.getId(), MONTH_REQUEST);
         coachService.putAvailableDateTimesByCoachId(COACH3.getId(), MONTH_REQUEST);
         coachService.putAvailableDateTimesByCoachId(COACH4.getId(), MONTH_REQUEST);
-        reservationService.create(COACH1.getId(),
-                new ReservationRequest("바니", LocalDateTime.of(NOW_PLUS_2_DAYS, FIRST_TIME), FORM_ITEM_REQUESTS));
-        reservationService.create(COACH2.getId(),
-                new ReservationRequest("열음", LocalDateTime.of(NOW_PLUS_2_DAYS, SECOND_TIME), FORM_ITEM_REQUESTS));
-        reservationService.create(COACH3.getId(),
-                new ReservationRequest("앤지", LocalDateTime.of(NOW_PLUS_3_DAYS, FIRST_TIME), FORM_ITEM_REQUESTS));
-        reservationService.create(COACH4.getId(),
-                new ReservationRequest("애쉬", LocalDateTime.of(NOW_PLUS_3_DAYS, SECOND_TIME), FORM_ITEM_REQUESTS));
+        reservationService.create(CREW1.getId(), COACH1.getId(),
+                new ReservationRequest(LocalDateTime.of(NOW_PLUS_2_DAYS, FIRST_TIME), FORM_ITEM_REQUESTS));
+        reservationService.create(CREW2.getId(), COACH2.getId(),
+                new ReservationRequest(LocalDateTime.of(NOW_PLUS_2_DAYS, SECOND_TIME), FORM_ITEM_REQUESTS));
+        reservationService.create(CREW3.getId(), COACH3.getId(),
+                new ReservationRequest(LocalDateTime.of(NOW_PLUS_3_DAYS, FIRST_TIME), FORM_ITEM_REQUESTS));
+        reservationService.create(CREW4.getId(), COACH4.getId(),
+                new ReservationRequest(LocalDateTime.of(NOW_PLUS_3_DAYS, SECOND_TIME), FORM_ITEM_REQUESTS));
 
         // when
         final List<ReservationResponse> reservationResponses = reservationService.findAllReservations();
@@ -124,7 +126,7 @@ class ReservationServiceTest {
         // then
         assertThat(reservationResponses).extracting("crewNickname")
                 .hasSize(4)
-                .contains("바니", "열음", "앤지", "애쉬");
+                .contains("수달", "앤지", "애쉬", "록바");
     }
 
     @Test
@@ -132,14 +134,14 @@ class ReservationServiceTest {
     void findAllByCoach() {
         // given
         coachService.putAvailableDateTimesByCoachId(COACH4.getId(), MONTH_REQUEST);
-        reservationService.create(COACH4.getId(),
-                new ReservationRequest("바니", LocalDateTime.of(NOW_PLUS_2_DAYS, FIRST_TIME), FORM_ITEM_REQUESTS));
-        reservationService.create(COACH4.getId(),
-                new ReservationRequest("열음", LocalDateTime.of(NOW_PLUS_2_DAYS, SECOND_TIME), FORM_ITEM_REQUESTS));
-        reservationService.create(COACH4.getId(),
-                new ReservationRequest("앤지", LocalDateTime.of(NOW_PLUS_3_DAYS, FIRST_TIME), FORM_ITEM_REQUESTS));
-        reservationService.create(COACH4.getId(),
-                new ReservationRequest("애쉬", LocalDateTime.of(NOW_PLUS_3_DAYS, SECOND_TIME), FORM_ITEM_REQUESTS));
+        reservationService.create(CREW1.getId(), COACH4.getId(),
+                new ReservationRequest(LocalDateTime.of(NOW_PLUS_2_DAYS, FIRST_TIME), FORM_ITEM_REQUESTS));
+        reservationService.create(CREW2.getId(), COACH4.getId(),
+                new ReservationRequest(LocalDateTime.of(NOW_PLUS_2_DAYS, SECOND_TIME), FORM_ITEM_REQUESTS));
+        reservationService.create(CREW3.getId(), COACH4.getId(),
+                new ReservationRequest(LocalDateTime.of(NOW_PLUS_3_DAYS, FIRST_TIME), FORM_ITEM_REQUESTS));
+        reservationService.create(CREW4.getId(), COACH4.getId(),
+                new ReservationRequest(LocalDateTime.of(NOW_PLUS_3_DAYS, SECOND_TIME), FORM_ITEM_REQUESTS));
 
         // when
         final ScheduleResponse scheduleResponses = reservationService.findAllByCoach(COACH4.getId(),
@@ -149,7 +151,7 @@ class ReservationServiceTest {
         // then
         assertThat(scheduleResponses.getCalendar()).extracting("crewNickname")
                 .hasSize(4)
-                .contains("바니", "열음", "앤지", "애쉬");
+                .contains("수달", "앤지", "애쉬", "록바");
     }
 
     @Test
@@ -159,8 +161,8 @@ class ReservationServiceTest {
         coachService.putAvailableDateTimesByCoachId(COACH4.getId(), PAST_REQUEST);
 
         // when & then
-        assertThatThrownBy(() -> reservationService.create(COACH4.getId(),
-                new ReservationRequest("SUDAL", LocalDateTime.of(LocalDate.now(), THIRD_TIME), FORM_ITEM_REQUESTS)))
+        assertThatThrownBy(() -> reservationService.create(CREW1.getId(), COACH4.getId(),
+                new ReservationRequest(LocalDateTime.of(LocalDate.now(), THIRD_TIME), FORM_ITEM_REQUESTS)))
                 .isInstanceOf(InvalidReservationDateException.class)
                 .hasMessage(ExceptionType.INVALID_RESERVATION_DATE.getMessage());
     }
@@ -172,9 +174,8 @@ class ReservationServiceTest {
         coachService.putAvailableDateTimesByCoachId(COACH4.getId(), PAST_REQUEST);
 
         // when & then
-        assertThatThrownBy(() -> reservationService.create(COACH4.getId(),
-                new ReservationRequest("SUDAL", LocalDateTime.of(LocalDate.now().minusDays(2), THIRD_TIME),
-                        FORM_ITEM_REQUESTS)))
+        assertThatThrownBy(() -> reservationService.create(CREW1.getId(), COACH4.getId(),
+                new ReservationRequest(LocalDateTime.of(LocalDate.now().minusDays(2), THIRD_TIME), FORM_ITEM_REQUESTS)))
                 .isInstanceOf(InvalidReservationDateException.class)
                 .hasMessage(ExceptionType.INVALID_RESERVATION_DATE.getMessage());
     }

--- a/backend/src/test/java/com/woowacourse/ternoko/service/ReservationServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/ternoko/service/ReservationServiceTest.java
@@ -60,15 +60,15 @@ class ReservationServiceTest {
     @Test
     @DisplayName("면담 예약을 생성한다.")
     void create() {
-        // given, when
+        // given
         coachService.putAvailableDateTimesByCoachId(COACH3.getId(), MONTH_REQUEST);
 
+        // when
         final Reservation reservation = reservationService.create(CREW1.getId(),
                 new ReservationRequest(COACH3.getId(), LocalDateTime.of(NOW_PLUS_2_DAYS, FIRST_TIME),
                         FORM_ITEM_REQUESTS));
-        final ReservationResponse reservationResponse = reservationService.findReservationById(reservation.getId());
-
         // then
+        final ReservationResponse reservationResponse = reservationService.findReservationById(reservation.getId());
         assertAll(
                 () -> assertThat(reservation.getId()).isNotNull(),
                 () -> assertThat(reservationResponse.getCoachNickname())
@@ -236,7 +236,7 @@ class ReservationServiceTest {
         // given
         coachService.putAvailableDateTimesByCoachId(COACH3.getId(), MONTH_REQUEST);
 
-        final Reservation reservation = reservationService.create(CREW1.getId(),
+        reservationService.create(CREW1.getId(),
                 new ReservationRequest(COACH3.getId(), LocalDateTime.of(NOW_PLUS_2_DAYS, FIRST_TIME),
                         FORM_ITEM_REQUESTS));
         // when
@@ -256,7 +256,7 @@ class ReservationServiceTest {
         final Reservation reservation = reservationService.create(CREW1.getId(),
                 new ReservationRequest(COACH3.getId(), LocalDateTime.of(NOW_PLUS_2_DAYS, FIRST_TIME),
                         FORM_ITEM_REQUESTS));
-        // when
+        // when & then
         assertThatThrownBy(() -> reservationService.update(CREW2.getId(), reservation.getId(),
                 new ReservationRequest(COACH3.getId(), LocalDateTime.of(NOW_PLUS_3_DAYS, SECOND_TIME),
                         FORM_ITEM_UPDATE_REQUESTS)))
@@ -273,7 +273,7 @@ class ReservationServiceTest {
         final Reservation reservation = reservationService.create(CREW1.getId(),
                 new ReservationRequest(COACH3.getId(), LocalDateTime.of(NOW_PLUS_2_DAYS, FIRST_TIME),
                         FORM_ITEM_REQUESTS));
-        // when
+        // when & then
         assertThatThrownBy(() -> reservationService.update(CREW1.getId(), reservation.getId(),
                 new ReservationRequest(5L, LocalDateTime.of(NOW_PLUS_3_DAYS, SECOND_TIME),
                         FORM_ITEM_UPDATE_REQUESTS)))
@@ -368,7 +368,7 @@ class ReservationServiceTest {
     }
 
     @Test
-    @DisplayName("코치가 면담 예약을 취소 시 본인의 면담 예약이 아닌 경우 예외를 반환한다..")
+    @DisplayName("코치가 면담 예약을 취소 시 본인의 면담 예약이 아닌 경우 예외를 반환한다.")
     void cancel_WhenInvalidCoachId() {
         // given
         coachService.putAvailableDateTimesByCoachId(COACH3.getId(), MONTH_REQUEST);

--- a/backend/src/test/java/com/woowacourse/ternoko/service/ReservationServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/ternoko/service/ReservationServiceTest.java
@@ -328,4 +328,21 @@ class ReservationServiceTest {
                 .isInstanceOf(InvalidReservationDateException.class)
                 .hasMessage(ExceptionType.INVALID_RESERVATION_DATE.getMessage());
     }
+
+    @Test
+    @DisplayName("면담 예약을 삭제한다.")
+    void delete() {
+        // given
+        coachService.putAvailableDateTimesByCoachId(COACH3.getId(), MONTH_REQUEST);
+
+        final Reservation reservation = reservationService.create(CREW1.getId(),
+                new ReservationRequest(COACH3.getId(), LocalDateTime.of(NOW_PLUS_2_DAYS, FIRST_TIME),
+                        FORM_ITEM_REQUESTS));
+        // when
+        Reservation updateReservation = reservationService.delete(CREW1.getId(), reservation.getId());
+
+        // then
+        assertThatThrownBy(() -> reservationService.findReservationById(updateReservation.getId()))
+                .isInstanceOf(ReservationNotFoundException.class);
+    }
 }

--- a/backend/src/test/java/com/woowacourse/ternoko/service/ReservationServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/ternoko/service/ReservationServiceTest.java
@@ -159,7 +159,6 @@ class ReservationServiceTest {
     void createReservationTodayException() {
         // given
         coachService.putAvailableDateTimesByCoachId(COACH4.getId(), PAST_REQUEST);
-
         // when & then
         assertThatThrownBy(() -> reservationService.create(CREW1.getId(), COACH4.getId(),
                 new ReservationRequest(LocalDateTime.of(LocalDate.now(), THIRD_TIME), FORM_ITEM_REQUESTS)))

--- a/backend/src/test/java/com/woowacourse/ternoko/service/ReservationServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/ternoko/service/ReservationServiceTest.java
@@ -3,7 +3,6 @@ package com.woowacourse.ternoko.service;
 import static com.woowacourse.ternoko.fixture.CoachAvailableTimeFixture.FIRST_TIME;
 import static com.woowacourse.ternoko.fixture.CoachAvailableTimeFixture.MONTH_REQUEST;
 import static com.woowacourse.ternoko.fixture.CoachAvailableTimeFixture.NOW;
-import static com.woowacourse.ternoko.fixture.CoachAvailableTimeFixture.NOW_MINUS_2_DAYS;
 import static com.woowacourse.ternoko.fixture.CoachAvailableTimeFixture.NOW_PLUS_2_DAYS;
 import static com.woowacourse.ternoko.fixture.CoachAvailableTimeFixture.NOW_PLUS_3_DAYS;
 import static com.woowacourse.ternoko.fixture.CoachAvailableTimeFixture.PAST_REQUEST;
@@ -57,8 +56,9 @@ class ReservationServiceTest {
         // given, when
         coachService.putAvailableDateTimesByCoachId(COACH3.getId(), MONTH_REQUEST);
 
-        final Reservation reservation = reservationService.create(CREW1.getId(), COACH3.getId(),
-                new ReservationRequest(LocalDateTime.of(NOW_PLUS_2_DAYS, FIRST_TIME), FORM_ITEM_REQUESTS));
+        final Reservation reservation = reservationService.create(CREW1.getId(),
+                new ReservationRequest(COACH3.getId(), LocalDateTime.of(NOW_PLUS_2_DAYS, FIRST_TIME),
+                        FORM_ITEM_REQUESTS));
         final ReservationResponse reservationResponse = reservationService.findReservationById(reservation.getId());
 
         // then
@@ -82,8 +82,9 @@ class ReservationServiceTest {
     @Test
     @DisplayName("면담 예약 선택 일자가 코치의 가능한 시간이 아닌 경우 예외가 발생한다.")
     void create_WhenInvalidAvailableDateTime() {
-        assertThatThrownBy(() -> reservationService.create(CREW1.getId(), COACH1.getId(),
-                new ReservationRequest(LocalDateTime.of(NOW_PLUS_2_DAYS, FIRST_TIME), FORM_ITEM_REQUESTS)))
+        assertThatThrownBy(() -> reservationService.create(CREW1.getId(),
+                new ReservationRequest(COACH1.getId(), LocalDateTime.of(NOW_PLUS_2_DAYS, FIRST_TIME),
+                        FORM_ITEM_REQUESTS)))
                 .isInstanceOf(InvalidReservationDateException.class)
                 .hasMessage(ExceptionType.INVALID_AVAILABLE_DATE_TIME.getMessage());
     }
@@ -91,8 +92,8 @@ class ReservationServiceTest {
     @Test
     @DisplayName("없는 코치로 예약할 시 예외가 발생한다.")
     void create_coachNotFound() {
-        assertThatThrownBy(() -> reservationService.create(CREW1.getId(), -1L,
-                new ReservationRequest(LocalDateTime.of(NOW_PLUS_2_DAYS, FIRST_TIME), FORM_ITEM_REQUESTS)))
+        assertThatThrownBy(() -> reservationService.create(CREW1.getId(),
+                new ReservationRequest(-1L, LocalDateTime.of(NOW_PLUS_2_DAYS, FIRST_TIME), FORM_ITEM_REQUESTS)))
                 .isInstanceOf(CoachNotFoundException.class);
     }
 
@@ -111,14 +112,18 @@ class ReservationServiceTest {
         coachService.putAvailableDateTimesByCoachId(COACH2.getId(), MONTH_REQUEST);
         coachService.putAvailableDateTimesByCoachId(COACH3.getId(), MONTH_REQUEST);
         coachService.putAvailableDateTimesByCoachId(COACH4.getId(), MONTH_REQUEST);
-        reservationService.create(CREW1.getId(), COACH1.getId(),
-                new ReservationRequest(LocalDateTime.of(NOW_PLUS_2_DAYS, FIRST_TIME), FORM_ITEM_REQUESTS));
-        reservationService.create(CREW2.getId(), COACH2.getId(),
-                new ReservationRequest(LocalDateTime.of(NOW_PLUS_2_DAYS, SECOND_TIME), FORM_ITEM_REQUESTS));
-        reservationService.create(CREW3.getId(), COACH3.getId(),
-                new ReservationRequest(LocalDateTime.of(NOW_PLUS_3_DAYS, FIRST_TIME), FORM_ITEM_REQUESTS));
-        reservationService.create(CREW4.getId(), COACH4.getId(),
-                new ReservationRequest(LocalDateTime.of(NOW_PLUS_3_DAYS, SECOND_TIME), FORM_ITEM_REQUESTS));
+        reservationService.create(CREW1.getId(),
+                new ReservationRequest(COACH1.getId(), LocalDateTime.of(NOW_PLUS_2_DAYS, FIRST_TIME),
+                        FORM_ITEM_REQUESTS));
+        reservationService.create(CREW2.getId(),
+                new ReservationRequest(COACH2.getId(), LocalDateTime.of(NOW_PLUS_2_DAYS, SECOND_TIME),
+                        FORM_ITEM_REQUESTS));
+        reservationService.create(CREW3.getId(),
+                new ReservationRequest(COACH3.getId(), LocalDateTime.of(NOW_PLUS_3_DAYS, FIRST_TIME),
+                        FORM_ITEM_REQUESTS));
+        reservationService.create(CREW4.getId(),
+                new ReservationRequest(COACH4.getId(), LocalDateTime.of(NOW_PLUS_3_DAYS, SECOND_TIME),
+                        FORM_ITEM_REQUESTS));
 
         // when
         final List<ReservationResponse> reservationResponses = reservationService.findAllReservations();
@@ -134,14 +139,18 @@ class ReservationServiceTest {
     void findAllByCoach() {
         // given
         coachService.putAvailableDateTimesByCoachId(COACH4.getId(), MONTH_REQUEST);
-        reservationService.create(CREW1.getId(), COACH4.getId(),
-                new ReservationRequest(LocalDateTime.of(NOW_PLUS_2_DAYS, FIRST_TIME), FORM_ITEM_REQUESTS));
-        reservationService.create(CREW2.getId(), COACH4.getId(),
-                new ReservationRequest(LocalDateTime.of(NOW_PLUS_2_DAYS, SECOND_TIME), FORM_ITEM_REQUESTS));
-        reservationService.create(CREW3.getId(), COACH4.getId(),
-                new ReservationRequest(LocalDateTime.of(NOW_PLUS_3_DAYS, FIRST_TIME), FORM_ITEM_REQUESTS));
-        reservationService.create(CREW4.getId(), COACH4.getId(),
-                new ReservationRequest(LocalDateTime.of(NOW_PLUS_3_DAYS, SECOND_TIME), FORM_ITEM_REQUESTS));
+        reservationService.create(CREW1.getId(),
+                new ReservationRequest(COACH4.getId(), LocalDateTime.of(NOW_PLUS_2_DAYS, FIRST_TIME),
+                        FORM_ITEM_REQUESTS));
+        reservationService.create(CREW2.getId(),
+                new ReservationRequest(COACH4.getId(), LocalDateTime.of(NOW_PLUS_2_DAYS, SECOND_TIME),
+                        FORM_ITEM_REQUESTS));
+        reservationService.create(CREW3.getId(),
+                new ReservationRequest(COACH4.getId(), LocalDateTime.of(NOW_PLUS_3_DAYS, FIRST_TIME),
+                        FORM_ITEM_REQUESTS));
+        reservationService.create(CREW4.getId(),
+                new ReservationRequest(COACH4.getId(), LocalDateTime.of(NOW_PLUS_3_DAYS, SECOND_TIME),
+                        FORM_ITEM_REQUESTS));
 
         // when
         final ScheduleResponse scheduleResponses = reservationService.findAllByCoach(COACH4.getId(),
@@ -160,8 +169,9 @@ class ReservationServiceTest {
         // given
         coachService.putAvailableDateTimesByCoachId(COACH4.getId(), PAST_REQUEST);
         // when & then
-        assertThatThrownBy(() -> reservationService.create(CREW1.getId(), COACH4.getId(),
-                new ReservationRequest(LocalDateTime.of(LocalDate.now(), THIRD_TIME), FORM_ITEM_REQUESTS)))
+        assertThatThrownBy(() -> reservationService.create(CREW1.getId(),
+                new ReservationRequest(COACH4.getId(), LocalDateTime.of(LocalDate.now(), THIRD_TIME),
+                        FORM_ITEM_REQUESTS)))
                 .isInstanceOf(InvalidReservationDateException.class)
                 .hasMessage(ExceptionType.INVALID_RESERVATION_DATE.getMessage());
     }
@@ -173,8 +183,9 @@ class ReservationServiceTest {
         coachService.putAvailableDateTimesByCoachId(COACH4.getId(), PAST_REQUEST);
 
         // when & then
-        assertThatThrownBy(() -> reservationService.create(CREW1.getId(), COACH4.getId(),
-                new ReservationRequest(LocalDateTime.of(LocalDate.now().minusDays(2), THIRD_TIME), FORM_ITEM_REQUESTS)))
+        assertThatThrownBy(() -> reservationService.create(CREW1.getId(),
+                new ReservationRequest(COACH4.getId(), LocalDateTime.of(LocalDate.now().minusDays(2), THIRD_TIME),
+                        FORM_ITEM_REQUESTS)))
                 .isInstanceOf(InvalidReservationDateException.class)
                 .hasMessage(ExceptionType.INVALID_RESERVATION_DATE.getMessage());
     }

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -31,7 +31,7 @@ slack:
   redirectUrl: 'https://localhost:8080/api/login'
   clientId: '3756998338916.3821665111344'
   clientSecret: '7db0d45bf9ae307a3a93522aa0cc4131'
-  botToken: 'xoxb-3756998338916-3842314970982-2gbLlR8ZCitbKyh0UUqaXYtB'
+  botToken: 'xoxb-3756998338916-3842314970982-ZIx3xN1Dr167rMdPKPqpM3W9'
 
 security:
   jwt:

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -31,6 +31,7 @@ slack:
   redirectUrl: 'https://localhost:8080/api/login'
   clientId: '3756998338916.3821665111344'
   clientSecret: '7db0d45bf9ae307a3a93522aa0cc4131'
+  botToken: 'xoxb-3756998338916-3842314970982-2gbLlR8ZCitbKyh0UUqaXYtB'
 
 security:
   jwt:

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -31,7 +31,7 @@ slack:
   redirectUrl: 'https://localhost:8080/api/login'
   clientId: '3756998338916.3821665111344'
   clientSecret: '7db0d45bf9ae307a3a93522aa0cc4131'
-  botToken: 'xoxb-3756998338916-3842314970982-ZIx3xN1Dr167rMdPKPqpM3W9'
+  botToken: 'xoxb-3756998338916-3842314970982-TeV0jfDkRCKO09JUadFkq2Xv'
 
 security:
   jwt:

--- a/backend/src/test/resources/data.sql
+++ b/backend/src/test/resources/data.sql
@@ -20,6 +20,9 @@ VALUES ('test1@woowahan.com',
         'CREW'),
        ('test7@woowahan.com',
         'https://user-images.githubusercontent.com/26570275/177680191-a4497404-c4cb-4f86-8c2c-f4f9c70bcaf7.png', '애쉬',
+        'CREW'),
+        ('test8@woowahan.com',
+        'https://user-images.githubusercontent.com/26570275/177680191-a4497404-c4cb-4f86-8c2c-f4f9c70bcaf7.png', '록바',
         'CREW');
 INSERT INTO COACH (id)
 VALUES (1),
@@ -30,4 +33,5 @@ VALUES (1),
 INSERT INTO CREW (id)
 VALUES (5),
        (6),
-       (7);
+       (7),
+       (8);

--- a/backend/src/test/resources/json/reservations/create-reservation1.json
+++ b/backend/src/test/resources/json/reservations/create-reservation1.json
@@ -1,5 +1,5 @@
 {
-  "crewNickname" : "바니",
+  "coachId" : 1,
   "interviewDatetime" : "2030-08-30 14:00",
   "interviewQuestions" :
   [

--- a/backend/src/test/resources/json/reservations/create-reservation2.json
+++ b/backend/src/test/resources/json/reservations/create-reservation2.json
@@ -1,5 +1,5 @@
 {
-  "crewNickname" : "열음",
+  "coachId" : 1,
   "interviewDatetime" : "2030-08-30 15:00",
   "interviewQuestions" :
   [


### PR DESCRIPTION
### Issues
- [ ] #104 
- [ ] #106 
- [ ] #107 
- [ ] #111 

### 논의사항
- 현재 해당 PR이 사이즈가 많이 커지는 것 같아 현재까지의 기능 구현(예약 취소 및 수정, 슬랙 알람) 후 PR 요청
    - 리팩터링이나 final, 미사용 import 제거가 미흡하며 개인적인 생각으로 코드를 작성하여 수정할 부분이 많을 것 같아 코드 리뷰 후 같이 리팩터링할 예정
- Schedule을 사용하는 알람 기능 같은 경우 이번 PR 머지 후 진행할 예정
- Test 코드도 누락된 예외 상황이 있을 것 같아 관련해서 코드 리뷰 필요 

### 주요 변경 사항  
1. Interview 클래스  기존 필드 crewNickname에서 Coach, Crew 클래스로 수정(Slack 정보 관련 userId 값 사용하기 위함.)
2. SlackAlarm Class 생성 : Slack 관련 클래스에 구현된 메서드를 통한 슬랙 알람 메서드 구현
3. 예약 취소 및 수정 기능 구현 : [크루] 예약 수정, 예약 삭제   /  [코치] 예약 취소
4. 면담 예약 API  수정 :  `/api/reservations/coaches/{coachId}` -> `/api/reservations`
    - coachId는 `ReservationRequest` 클래스 필드로 전달
5. Interview 클래스 상태 필드 추가 - InterviewStatusType enum 클래스로 구현

개인적으로 작성한 부분이 많아서 관련하여 궁금한 사항이 많을 것으로 예상됩니다. 궁금한 부분이나 수정해야할 부분에 대해서 리뷰 부탁드리며 직접 질문해주셔도 좋습니다.  
감사합니다.

## 참고자료
- JPA 관계 매핑 CASCADE 옵션 - [링크](https://abbo.tistory.com/276)

close #104 
close #106 
close #107 
close #111 


