### PR TITLE
[BE] fix: 회원 이미지 수정 및 코치 정보 수정 시 이미지 저장 기능 구현 #173

### DIFF
--- a/backend/src/main/java/com/woowacourse/ternoko/dto/CoachUpdateRequest.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/dto/CoachUpdateRequest.java
@@ -12,6 +12,6 @@ import lombok.NoArgsConstructor;
 public class CoachUpdateRequest {
 
     private String nickname;
-    private String imagUrl;
+    private String imageUrl;
     private String introduce;
 }

--- a/backend/src/main/java/com/woowacourse/ternoko/service/AuthService.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/service/AuthService.java
@@ -95,12 +95,12 @@ public class AuthService {
     private LoginResponse signUp(final OpenIDConnectUserInfoResponse userInfoResponse) {
         if (userInfoResponse.getEmail().contains(WOOWAHAN_COACH_EMAIL)) {
             final Coach coach = coachRepository.save(new Coach(userInfoResponse.getName(), userInfoResponse.getEmail(),
-                    userInfoResponse.getUserId(), userInfoResponse.getTeamImage230()));
+                    userInfoResponse.getUserId(), userInfoResponse.getUserImage192()));
             return LoginResponse.of(Type.COACH, jwtProvider.createToken(String.valueOf(coach.getId())), false);
         }
 
         final Crew crew = crewRepository.save(new Crew(userInfoResponse.getName(), userInfoResponse.getEmail(),
-                userInfoResponse.getUserId(), userInfoResponse.getTeamImage230()));
+                userInfoResponse.getUserId(), userInfoResponse.getUserImage192()));
 
         return LoginResponse.of(Type.CREW, jwtProvider.createToken(String.valueOf(crew.getId())), false);
     }

--- a/backend/src/main/java/com/woowacourse/ternoko/service/CoachService.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/service/CoachService.java
@@ -82,6 +82,6 @@ public class CoachService {
 
     public void partUpdateCrew(Long coachId, CoachUpdateRequest coachUpdateRequest) {
         coachRepository.updateNickNameAndImageUrlAndIntroduce(coachId, coachUpdateRequest.getNickname(),
-                coachUpdateRequest.getImagUrl(), coachUpdateRequest.getIntroduce());
+                coachUpdateRequest.getImageUrl(), coachUpdateRequest.getIntroduce());
     }
 }


### PR DESCRIPTION
### Issues
- [ ] #173 
- [ ] #174 

### 논의사항
- CrewUpdateReqeust - imageUrl 필드 오타 수정
- 기존 팀 이미지를 저장했던 상태에서 Slack UserImage를 저장할 수 있도록 수정 
close #173 
close #174 


