### PR TITLE
[BE] chore: restDocs html 파일 경로 찾지 못하는 문제 빌드파일 수정

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -60,6 +60,7 @@ dependencies {
     asciidoctorExtensions 'org.springframework.restdocs:spring-restdocs-asciidoctor'
 }
 
+
 ext {
     snippetsDir = file('build/generated-snippets')
 }
@@ -77,6 +78,7 @@ test {
 
 asciidoctor {
     configurations 'asciidoctorExtensions'
+    baseDirFollowsSourceFile()
     inputs.dir snippetsDir
     dependsOn test
 }
@@ -85,25 +87,20 @@ asciidoctor.doFirst {
     delete file('src/main/resources/static/docs')
 }
 
-bootJar {
-    dependsOn asciidoctor
-    copy {
-        from "${asciidoctor.outputDir}"
-        into 'static/docs'
-    }
-}
-
 task copyDocument(type: Copy) {
     dependsOn asciidoctor
     from file("build/docs/asciidoc")
     into file("src/main/resources/static/docs")
 }
 
-build {
+bootJar {
     dependsOn copyDocument
+    copy {
+        from "${asciidoctor.outputDir}"
+        into 'static/docs'
+    }
 }
 
-
-tasks.named('test') {
-    useJUnitPlatform()
+build {
+    dependsOn copyDocument
 }


### PR DESCRIPTION
### Issues
- [ ] #179 

### 논의사항
터미널에서
1. `./gradlew clean build -x checkstyleMain -x checkstyleTest`를 실행
2. `java -jar build/libs/ternoko-0.0.1-SNAPSHOT.jar` jar 파일 실행 
실행 후
`https://localhost:8080/docs/api.html` 로 접근 확인하실 수 있습니다.

close #179 


