### PR TITLE
[BE] refactor: 면담 예약 신청,수정 시 크루의 이미 존재하는 예약의 날짜와 시간인 경우 예외 추가

### DIFF
--- a/backend/src/main/java/com/woowacourse/ternoko/common/exception/ExceptionType.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/common/exception/ExceptionType.java
@@ -14,6 +14,7 @@ public enum ExceptionType {
     INVALID_RESERVATION_CREW_ID(HttpStatus.BAD_REQUEST, "다른 크루의 예약에 접근할 수 없습니다."),
     INVALID_RESERVATION_COACH_ID(HttpStatus.BAD_REQUEST, "다른 코치의 예약에 접근할 수 없습니다."),
     INVALID_RESERVATION_DATE(HttpStatus.BAD_REQUEST, "면담 예약은 최소 하루 전에 가능 합니다."),
+    INVALID_RESERVATION_DUPLICATE_DATE_TIME(HttpStatus.BAD_REQUEST, "면담 예약은 같은 시간, 같은 코치에 단 한번 가능합니다."),
     INVALID_AVAILABLE_DATE_TIME(HttpStatus.BAD_REQUEST, "선택한 날짜는 해당 코치의 가능한 시간이 아닙니다."),
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다"),
     EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "토큰이 만료되었습니다."),

--- a/backend/src/main/java/com/woowacourse/ternoko/repository/InterviewRepository.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/repository/InterviewRepository.java
@@ -13,4 +13,6 @@ public interface InterviewRepository extends JpaRepository<Interview, Long> {
                                                  final Long coachId);
 
     List<Interview> findAllByCrewIdOrderByInterviewStartTime(final Long crewId);
+
+    boolean existsByCrewIdAndInterviewStartTime(final Long crewId, final LocalDateTime start);
 }

--- a/backend/src/main/java/com/woowacourse/ternoko/service/ReservationService.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/service/ReservationService.java
@@ -83,9 +83,7 @@ public class ReservationService {
         final Coach coach = coachRepository.findById(reservationRequest.getCoachId())
                 .orElseThrow(() -> new CoachNotFoundException(COACH_NOT_FOUND, reservationRequest.getCoachId()));
 
-        if (interviewRepository.existsByCrewIdAndInterviewStartTime(crewId, reservationRequest.getInterviewDatetime())) {
-            throw new InvalidReservationDateException(INVALID_RESERVATION_DUPLICATE_DATE_TIME);
-        }
+        validateDuplicateStartTime(crewId, reservationRequest);
         validateInterviewStartTime(reservationDatetime);
 
         return new Interview(
@@ -93,6 +91,13 @@ public class ReservationService {
                 reservationDatetime.plusMinutes(30),
                 coach,
                 crew);
+    }
+
+    private void validateDuplicateStartTime(Long crewId, ReservationRequest reservationRequest) {
+        if (interviewRepository.existsByCrewIdAndInterviewStartTime(crewId,
+                reservationRequest.getInterviewDatetime())) {
+            throw new InvalidReservationDateException(INVALID_RESERVATION_DUPLICATE_DATE_TIME);
+        }
     }
 
     private void validateInterviewStartTime(final LocalDateTime localDateTime) {

--- a/backend/src/main/java/com/woowacourse/ternoko/service/ReservationService.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/service/ReservationService.java
@@ -6,6 +6,7 @@ import static com.woowacourse.ternoko.common.exception.ExceptionType.INVALID_AVA
 import static com.woowacourse.ternoko.common.exception.ExceptionType.INVALID_RESERVATION_COACH_ID;
 import static com.woowacourse.ternoko.common.exception.ExceptionType.INVALID_RESERVATION_CREW_ID;
 import static com.woowacourse.ternoko.common.exception.ExceptionType.INVALID_RESERVATION_DATE;
+import static com.woowacourse.ternoko.common.exception.ExceptionType.INVALID_RESERVATION_DUPLICATE_DATE_TIME;
 import static com.woowacourse.ternoko.common.exception.ExceptionType.RESERVATION_NOT_FOUND;
 
 import com.woowacourse.ternoko.common.exception.CoachNotFoundException;
@@ -82,6 +83,9 @@ public class ReservationService {
         final Coach coach = coachRepository.findById(reservationRequest.getCoachId())
                 .orElseThrow(() -> new CoachNotFoundException(COACH_NOT_FOUND, reservationRequest.getCoachId()));
 
+        if (interviewRepository.existsByCrewIdAndInterviewStartTime(crewId, reservationRequest.getInterviewDatetime())) {
+            throw new InvalidReservationDateException(INVALID_RESERVATION_DUPLICATE_DATE_TIME);
+        }
         validateInterviewStartTime(reservationDatetime);
 
         return new Interview(

--- a/backend/src/test/java/com/woowacourse/ternoko/acceptance/ReservationAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/ternoko/acceptance/ReservationAcceptanceTest.java
@@ -3,6 +3,7 @@ package com.woowacourse.ternoko.acceptance;
 import static com.woowacourse.ternoko.fixture.CoachAvailableTimeFixture.FIRST_TIME;
 import static com.woowacourse.ternoko.fixture.CoachAvailableTimeFixture.MONTHS_REQUEST;
 import static com.woowacourse.ternoko.fixture.CoachAvailableTimeFixture.NOW_PLUS_2_DAYS;
+import static com.woowacourse.ternoko.fixture.CoachAvailableTimeFixture.NOW_PLUS_3_DAYS;
 import static com.woowacourse.ternoko.fixture.CoachAvailableTimeFixture.SECOND_TIME;
 import static com.woowacourse.ternoko.fixture.MemberFixture.COACH1;
 import static com.woowacourse.ternoko.fixture.MemberFixture.COACH2;
@@ -88,7 +89,7 @@ class ReservationAcceptanceTest extends AcceptanceTest {
         put("/api/calendar/times", generateHeader(COACH4.getId()), MONTHS_REQUEST);
 
         createReservation(CREW1.getId(), COACH1.getId(), LocalDateTime.of(NOW_PLUS_2_DAYS, FIRST_TIME));
-        createReservation(CREW1.getId(), COACH2.getId(), LocalDateTime.of(NOW_PLUS_2_DAYS, FIRST_TIME));
+        createReservation(CREW1.getId(), COACH2.getId(), LocalDateTime.of(NOW_PLUS_3_DAYS, SECOND_TIME));
         createReservation(CREW3.getId(), COACH3.getId(), LocalDateTime.of(NOW_PLUS_2_DAYS, FIRST_TIME));
         createReservation(CREW4.getId(), COACH4.getId(), LocalDateTime.of(NOW_PLUS_2_DAYS, FIRST_TIME));
 

--- a/backend/src/test/java/com/woowacourse/ternoko/api/ControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/ternoko/api/ControllerTest.java
@@ -10,9 +10,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.springframework.http.MediaType;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
+@DirtiesContext(classMode = ClassMode.AFTER_EACH_TEST_METHOD)
 public class ControllerTest extends RestDocsTestSupport {
 
     protected final ObjectMapper objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());

--- a/backend/src/test/java/com/woowacourse/ternoko/api/ReservationControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/ternoko/api/ReservationControllerTest.java
@@ -37,11 +37,11 @@ public class ReservationControllerTest extends ControllerTest {
     void findReservationById() throws Exception {
         // given
         createCalendarTimes(COACH1.getId());
-        createReservations(CREW1.getId());
+        final Long reservationId = createReservation(CREW1.getId());
 
         // when, then
         mockMvc.perform(MockMvcRequestBuilders
-                        .get("/api/reservations/{reservationId}", 1)
+                        .get("/api/reservations/{reservationId}", reservationId)
                         .header(AUTHORIZATION, BEARER_TYPE + jwtProvider.createToken(String.valueOf(CREW1.getId()))))
                 .andExpect(status().isOk())
                 .andDo(restDocs.document());


### PR DESCRIPTION
### Issues
- [ ] #156 

### 논의사항
PR 브랜치 잘못 보내 다시 올립니다. 남겨주신 리뷰 반영하였습니다 !

ReservationService 클래스의 create, update 함수 안의 convertIntervew() 메서드에서 검증 로직을 추가 했습니다.

해당 메서드에서 코치, 크루 존재 여부 검증, 인터뷰 시작날짜 검증이 이루어지고 있기 때문에, 같은 메서드안에 추가하였습니다.

close #156 
