### PR TITLE
[BE] fix:  코치 월별 일정 조회시, canceled 된 interview filtering

### DIFF
--- a/backend/src/docs/asciidoc/api.adoc
+++ b/backend/src/docs/asciidoc/api.adoc
@@ -236,7 +236,7 @@ operation::interview-controller-test/create-interview[snippets='http-request,htt
 === [코치] 면담 예약 목록 조회 API
 GET /api/schedules?year={year}&month={month}
 
-operation::coach-controller-test/find-all-interview-by-coach[snippets='http-request,http-response']
+operation::coach-controller-test/find-calendar-times[snippets='http-request,http-response']
 ==== Error Response
 |===
 | statusCode | message

--- a/backend/src/main/java/com/woowacourse/ternoko/controller/CoachController.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/controller/CoachController.java
@@ -25,13 +25,6 @@ public class CoachController {
 
     private final CoachService coachService;
 
-    @PutMapping("/calendar/times")
-    public ResponseEntity<Void> saveCalendarTimes(@AuthenticationPrincipal final Long coachId,
-                                                  @RequestBody final CalendarRequest calendarRequest) {
-        coachService.putAvailableDateTimesByCoachId(coachId, calendarRequest);
-        return ResponseEntity.ok().build();
-    }
-
     @GetMapping("/calendar/times")
     public ResponseEntity<AvailableDateTimesResponse> findCalendarTimes(@RequestParam final Long coachId,
                                                                         @RequestParam final int year,
@@ -40,6 +33,13 @@ public class CoachController {
                 .findAvailableDateTimesByCoachId(coachId, year, month);
         final AvailableDateTimesResponse from = AvailableDateTimesResponse.from(availableDateTimes);
         return ResponseEntity.ok(from);
+    }
+
+    @PutMapping("/calendar/times")
+    public ResponseEntity<Void> saveCalendarTimes(@AuthenticationPrincipal final Long coachId,
+                                                  @RequestBody final CalendarRequest calendarRequest) {
+        coachService.putAvailableDateTimesByCoachId(coachId, calendarRequest);
+        return ResponseEntity.ok().build();
     }
 
     @GetMapping("/coaches/me")

--- a/backend/src/main/java/com/woowacourse/ternoko/domain/InterviewStatusType.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/domain/InterviewStatusType.java
@@ -5,5 +5,9 @@ public enum InterviewStatusType {
     FIX,
     FEEDBACK,
     COMPLETED,
-    CANCELED
+    CANCELED;
+
+    public static boolean isCanceled(InterviewStatusType type) {
+        return CANCELED.equals(type);
+    }
 }

--- a/backend/src/main/java/com/woowacourse/ternoko/interview/application/InterviewService.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/interview/application/InterviewService.java
@@ -136,11 +136,11 @@ public class InterviewService {
         final List<Interview> interviews = interviewRepository
                 .findAllByCoachIdAndDateRange(startOfMonth, endOfMonth, coachId);
 
-        final List<Interview> result = interviews.stream()
+        final List<Interview> excludeCanceledInterviews = interviews.stream()
                 .filter(interview -> !InterviewStatusType.isCanceled(interview.getInterviewStatusType()))
                 .collect(Collectors.toList());
 
-        return ScheduleResponse.from(result);
+        return ScheduleResponse.from(excludeCanceledInterviews);
     }
 
     public Interview update(final Long crewId,

--- a/backend/src/main/java/com/woowacourse/ternoko/interview/application/InterviewService.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/interview/application/InterviewService.java
@@ -13,6 +13,7 @@ import com.woowacourse.ternoko.availabledatetime.domain.AvailableDateTime;
 import com.woowacourse.ternoko.availabledatetime.domain.AvailableDateTimeRepository;
 import com.woowacourse.ternoko.common.exception.CoachNotFoundException;
 import com.woowacourse.ternoko.common.exception.CrewNotFoundException;
+import com.woowacourse.ternoko.domain.InterviewStatusType;
 import com.woowacourse.ternoko.domain.member.Coach;
 import com.woowacourse.ternoko.domain.member.Crew;
 import com.woowacourse.ternoko.interview.domain.FormItem;
@@ -135,7 +136,11 @@ public class InterviewService {
         final List<Interview> interviews = interviewRepository
                 .findAllByCoachIdAndDateRange(startOfMonth, endOfMonth, coachId);
 
-        return ScheduleResponse.from(interviews);
+        final List<Interview> result = interviews.stream()
+                .filter(interview -> !InterviewStatusType.isCanceled(interview.getInterviewStatusType()))
+                .collect(Collectors.toList());
+
+        return ScheduleResponse.from(result);
     }
 
     public Interview update(final Long crewId,

--- a/backend/src/test/java/com/woowacourse/ternoko/interview/application/InterviewServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/ternoko/interview/application/InterviewServiceTest.java
@@ -188,6 +188,37 @@ class InterviewServiceTest {
     }
 
     @Test
+    @DisplayName("코치별로 면담예약 목록을 조회할 시, 취소된 면담은 제와하고 보낸다.")
+    void findAllByCoach_except_interviewStatus_canceled() {
+        // given
+        coachService.putAvailableDateTimesByCoachId(COACH4.getId(), MONTH_REQUEST);
+        interviewService.create(CREW1.getId(),
+                new InterviewRequest(COACH4.getId(), LocalDateTime.of(NOW_PLUS_2_DAYS, FIRST_TIME),
+                        FORM_ITEM_REQUESTS));
+        interviewService.create(CREW2.getId(),
+                new InterviewRequest(COACH4.getId(), LocalDateTime.of(NOW_PLUS_2_DAYS, SECOND_TIME),
+                        FORM_ITEM_REQUESTS));
+        interviewService.create(CREW3.getId(),
+                new InterviewRequest(COACH4.getId(), LocalDateTime.of(NOW_PLUS_3_DAYS, FIRST_TIME),
+                        FORM_ITEM_REQUESTS));
+        final Interview interview = interviewService.create(CREW4.getId(),
+                new InterviewRequest(COACH4.getId(), LocalDateTime.of(NOW_PLUS_3_DAYS, SECOND_TIME),
+                        FORM_ITEM_REQUESTS));
+
+        interviewService.cancel(COACH4.getId(), interview.getId());
+
+        // when
+        final ScheduleResponse scheduleResponses = interviewService.findAllByCoach(COACH4.getId(),
+                NOW.getYear(),
+                NOW.getMonthValue());
+
+        // then
+        assertThat(scheduleResponses.getCalendar()).extracting("crewNickname")
+                .hasSize(3)
+                .contains("수달", "앤지", "애쉬");
+    }
+
+    @Test
     @DisplayName("면담 예약시, 당일 예약을 시도하면 에러가 발생한다.")
     void createInterviewTodayException() {
         // given

--- a/backend/src/test/java/com/woowacourse/ternoko/interview/application/InterviewServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/ternoko/interview/application/InterviewServiceTest.java
@@ -188,7 +188,7 @@ class InterviewServiceTest {
     }
 
     @Test
-    @DisplayName("코치별로 면담예약 목록을 조회할 시, 취소된 면담은 제와하고 보낸다.")
+    @DisplayName("코치별로 면담예약 목록을 조회할 시, 취소된 면담은 제외하고 보낸다.")
     void findAllByCoach_except_interviewStatus_canceled() {
         // given
         coachService.putAvailableDateTimesByCoachId(COACH4.getId(), MONTH_REQUEST);


### PR DESCRIPTION
### Issues
- [ ] #206 

### 논의사항
코치 월별 일정 조회에 관련된 ControllerTest 없음. RestDocs 없음 !

close #206 


