### PR TITLE
[BE] feat: 면담 수정시 면담 가능한 시간 조회 API 구현

### DIFF
--- a/backend/src/docs/asciidoc/api.adoc
+++ b/backend/src/docs/asciidoc/api.adoc
@@ -221,6 +221,26 @@ operation::coach-controller-test/find-calendar-times[snippets='http-request,http
 |`토큰이 존재하지 않습니다.`
 |===
 
+=== [크루] 면담 수정시 면담 가능 시간 조회 API
+
+GET /api/interviews/1/calendar/times?coachId={coachId}&year={year}&month={month}
+
+operation::coach-controller-test/find-calendar-times-by-interview-id[snippets='http-request,http-response']
+==== Error Response
+
+|===
+| statusCode | message
+
+| 401
+| `유효하지 않은 토큰입니다.`
+
+| 401
+| `토큰이 만료되었습니다.`
+
+| 401
+| `토큰이 존재하지 않습니다.`
+|===
+
 == 면담 예약 API
 
 === [크루] 코치 목록 조회 API

--- a/backend/src/main/java/com/woowacourse/ternoko/availabledatetime/domain/AvailableDateTime.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/availabledatetime/domain/AvailableDateTime.java
@@ -1,8 +1,5 @@
 package com.woowacourse.ternoko.availabledatetime.domain;
 
-import static com.woowacourse.ternoko.availabledatetime.domain.AvailableDateTimeStatus.OPEN;
-import static com.woowacourse.ternoko.availabledatetime.domain.AvailableDateTimeStatus.USED;
-
 import java.time.LocalDateTime;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -12,11 +9,13 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
+@EqualsAndHashCode
 @NoArgsConstructor
 @AllArgsConstructor
 public class AvailableDateTime {
@@ -41,11 +40,7 @@ public class AvailableDateTime {
         this.availableDateTimeStatus = availableDateTimeStatus;
     }
 
-    public void open() {
-        this.availableDateTimeStatus = OPEN;
-    }
-
-    public void used() {
-        this.availableDateTimeStatus = USED;
+    public void changeStatus(final AvailableDateTimeStatus status) {
+        this.availableDateTimeStatus = status;
     }
 }

--- a/backend/src/main/java/com/woowacourse/ternoko/availabledatetime/domain/AvailableDateTimeRepository.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/availabledatetime/domain/AvailableDateTimeRepository.java
@@ -10,12 +10,37 @@ import org.springframework.data.jpa.repository.Query;
 public interface AvailableDateTimeRepository extends JpaRepository<AvailableDateTime, Long> {
 
     @Modifying(clearAutomatically = true)
-    @Query("delete from AvailableDateTime a where a.coachId = :coachId and YEAR(a.localDateTime) = :year and MONTH(a.localDateTime) = :month")
-    void deleteAllByCoachAndYearAndMonth(final Long coachId, final int year, final int month);
+    @Query("delete from AvailableDateTime a "
+            + "where a.coachId = :coachId "
+            + "and YEAR(a.localDateTime) = :year "
+            + "and MONTH(a.localDateTime) = :month")
+    void deleteAllByCoachAndYearAndMonth(final Long coachId,
+                                         final int year,
+                                         final int month);
 
-    @Query("select a from AvailableDateTime a where a.coachId = :coachId and YEAR(a.localDateTime) = :year and MONTH(a.localDateTime) = :month")
-    List<AvailableDateTime> findAvailableDateTimesByCoachId(final Long coachId, final int year, final int month);
+    @Query("select a from AvailableDateTime a "
+            + "where a.coachId = :coachId "
+            + "and YEAR(a.localDateTime) = :year "
+            + "and MONTH(a.localDateTime) = :month")
+    List<AvailableDateTime> findAvailableDateTimesByCoachId(final Long coachId,
+                                                            final int year,
+                                                            final int month);
 
-    @Query("select a from AvailableDateTime a where a.coachId = :coachId and a.localDateTime = :interviewDateTime")
-    Optional<AvailableDateTime> findByCoachIdAndInterviewDateTime(Long coachId, LocalDateTime interviewDateTime);
+    @Query("select a from AvailableDateTime a "
+            + "where a.coachId = :coachId "
+            + "and a.localDateTime = :interviewDateTime")
+    Optional<AvailableDateTime> findByCoachIdAndInterviewDateTime(final Long coachId,
+                                                                  final LocalDateTime interviewDateTime);
+
+    @Query("select a from AvailableDateTime a "
+            + "where a.coachId = :coachId "
+            + "and YEAR(a.localDateTime) = :year "
+            + "and MONTH(a.localDateTime) = :month "
+            + "and a.availableDateTimeStatus = 'OPEN' "
+            + "or a.localDateTime = (select i.interviewStartTime from Interview i where i.id = :interviewId) "
+            + "order by a.localDateTime")
+    List<AvailableDateTime> findAvailableDateTimesByCoachIdAndInterviewId(final Long interviewId,
+                                                                          final Long coachId,
+                                                                          final int year,
+                                                                          final int month);
 }

--- a/backend/src/main/java/com/woowacourse/ternoko/availabledatetime/dto/AvailableDateTimeResponse.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/availabledatetime/dto/AvailableDateTimeResponse.java
@@ -5,11 +5,13 @@ import com.woowacourse.ternoko.availabledatetime.domain.AvailableDateTimeStatus;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @Builder
+@EqualsAndHashCode
 @NoArgsConstructor
 @AllArgsConstructor
 public class AvailableDateTimeResponse {

--- a/backend/src/main/java/com/woowacourse/ternoko/availabledatetime/dto/AvailableDateTimesResponse.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/availabledatetime/dto/AvailableDateTimesResponse.java
@@ -14,7 +14,7 @@ public class AvailableDateTimesResponse {
 
     private List<AvailableDateTimeResponse> calendarTimes;
 
-    public static AvailableDateTimesResponse from(final List<AvailableDateTime> availableDateTimes) {
+    public static AvailableDateTimesResponse of(final List<AvailableDateTime> availableDateTimes) {
         return new AvailableDateTimesResponse(availableDateTimes.stream()
                 .map(data -> new AvailableDateTimeResponse(data.getLocalDateTime(),
                         data.getAvailableDateTimeStatus()))

--- a/backend/src/main/java/com/woowacourse/ternoko/controller/CoachController.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/controller/CoachController.java
@@ -13,6 +13,7 @@ import lombok.AllArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -32,8 +33,8 @@ public class CoachController {
                                                                         @RequestParam final int month) {
         final List<AvailableDateTime> availableDateTimes = coachService
                 .findAvailableDateTimesByCoachId(coachId, year, month);
-        final AvailableDateTimesResponse from = AvailableDateTimesResponse.from(availableDateTimes);
-        return ResponseEntity.ok(from);
+        final AvailableDateTimesResponse response = AvailableDateTimesResponse.of(availableDateTimes);
+        return ResponseEntity.ok(response);
     }
 
     @CoachOnly
@@ -56,5 +57,17 @@ public class CoachController {
                                             @RequestBody final CoachUpdateRequest coachUpdateRequest) {
         coachService.partUpdateCrew(coachId, coachUpdateRequest);
         return ResponseEntity.ok().build();
+    }
+
+    // TODO: AvailableDateTimeController 로 옮기기
+    @GetMapping("/interviews/{interviewId}/calendar/times")
+    public ResponseEntity<AvailableDateTimesResponse> findCalendarTimesByInterviewId(@PathVariable final Long interviewId,
+                                                                        @RequestParam final Long coachId,
+                                                                        @RequestParam final int year,
+                                                                        @RequestParam final int month) {
+        final List<AvailableDateTime> availableDateTimes = coachService
+                .findAvailableDateTimesByCoachIdAndInterviewId(interviewId, coachId, year, month);
+        final AvailableDateTimesResponse response = AvailableDateTimesResponse.of(availableDateTimes);
+        return ResponseEntity.ok(response);
     }
 }

--- a/backend/src/main/java/com/woowacourse/ternoko/interview/application/InterviewService.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/interview/application/InterviewService.java
@@ -1,5 +1,7 @@
 package com.woowacourse.ternoko.interview.application;
 
+import static com.woowacourse.ternoko.availabledatetime.domain.AvailableDateTimeStatus.OPEN;
+import static com.woowacourse.ternoko.availabledatetime.domain.AvailableDateTimeStatus.USED;
 import static com.woowacourse.ternoko.common.exception.ExceptionType.COACH_NOT_FOUND;
 import static com.woowacourse.ternoko.common.exception.ExceptionType.CREW_NOT_FOUND;
 import static com.woowacourse.ternoko.common.exception.ExceptionType.INTERVIEW_NOT_FOUND;
@@ -71,7 +73,7 @@ public class InterviewService {
         formItemRepository.saveAll(formItems);
 
         final AvailableDateTime availableDateTime = findAvailableTime(interviewRequest);
-        availableDateTime.used();
+        availableDateTime.changeStatus(USED);
 
         return interviewRepository.save(interview);
     }
@@ -171,8 +173,8 @@ public class InterviewService {
         final AvailableDateTime beforeAvailableDateTime = findAvailableTime(originalInterview.getCoach().getId(),
                 originalInterview.getInterviewStartTime());
         final AvailableDateTime afterAvailableDateTime = findAvailableTime(interviewRequest);
-        beforeAvailableDateTime.open();
-        afterAvailableDateTime.used();
+        beforeAvailableDateTime.changeStatus(OPEN);
+        afterAvailableDateTime.changeStatus(USED);
     }
 
     private void updateFromItem(Interview originalInterview, Interview updateInterviewRequest,
@@ -214,8 +216,7 @@ public class InterviewService {
             availableDateTimeRepository.delete(unAvailableTime);
             return canceledInterview;
         }
-
-        unAvailableTime.open();
+        unAvailableTime.changeStatus(OPEN);
         return canceledInterview;
     }
 

--- a/backend/src/main/java/com/woowacourse/ternoko/interview/application/InterviewService.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/interview/application/InterviewService.java
@@ -246,6 +246,6 @@ public class InterviewService {
         Optional<AvailableDateTime> time = availableDateTimeRepository
                 .findByCoachIdAndInterviewDateTime(interview.getCoach().getId(),
                         interview.getInterviewStartTime());
-        time.ifPresent(AvailableDateTime::open);
+        time.ifPresent(it -> it.changeStatus(OPEN));
     }
 }

--- a/backend/src/main/java/com/woowacourse/ternoko/service/CoachService.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/service/CoachService.java
@@ -84,6 +84,17 @@ public class CoachService {
                 .collect(Collectors.toList());
     }
 
+    @Transactional(readOnly = true)
+    public List<AvailableDateTime> findAvailableDateTimesByCoachIdAndInterviewId(
+            final Long interviewId,
+            final Long coachId,
+            final int year,
+            final int month) {
+
+        return availableDateTimeRepository
+                .findAvailableDateTimesByCoachIdAndInterviewId(interviewId, coachId, year, month);
+    }
+
     public void partUpdateCrew(Long coachId, CoachUpdateRequest coachUpdateRequest) {
         coachRepository.updateNickNameAndImageUrlAndIntroduce(coachId, coachUpdateRequest.getNickname(),
                 coachUpdateRequest.getImageUrl(), coachUpdateRequest.getIntroduce());

--- a/backend/src/test/java/com/woowacourse/ternoko/acceptance/AcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/ternoko/acceptance/AcceptanceTest.java
@@ -143,4 +143,8 @@ public class AcceptanceTest {
     protected Header generateHeader(final Member member) {
         return new Header(AUTHORIZATION, BEARER_TYPE + jwtProvider.createToken(member));
     }
+
+    protected Long parseLocationHeader(final ExtractableResponse<Response> response, final String regex) {
+        return Long.parseLong(response.header("Location").split(regex)[1]);
+    }
 }

--- a/backend/src/test/java/com/woowacourse/ternoko/acceptance/InterviewAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/ternoko/acceptance/InterviewAcceptanceTest.java
@@ -71,11 +71,14 @@ class InterviewAcceptanceTest extends AcceptanceTest {
         final InterviewResponse interviewResponse = response.body().as(InterviewResponse.class);
 
         // then
-        assertAll(() -> assertThat(interviewResponse.getCoachNickname()).isEqualTo(COACH3.getNickname()),
-                () -> assertThat(interviewResponse.getInterviewStartTime()).isEqualTo(
-                        LocalDateTime.of(NOW_PLUS_2_DAYS, FIRST_TIME)),
-                () -> assertThat(interviewResponse.getInterviewEndTime()).isEqualTo(
-                        LocalDateTime.of(NOW_PLUS_2_DAYS, FIRST_TIME).plusMinutes(INTERVIEW_TIME)));
+        assertAll(
+                () -> assertThat(interviewResponse.getCoachNickname())
+                        .isEqualTo(COACH3.getNickname()),
+                () -> assertThat(interviewResponse.getInterviewStartTime())
+                        .isEqualTo(LocalDateTime.of(NOW_PLUS_2_DAYS, FIRST_TIME)),
+                () -> assertThat(interviewResponse.getInterviewEndTime())
+                        .isEqualTo(LocalDateTime.of(NOW_PLUS_2_DAYS, FIRST_TIME).plusMinutes(INTERVIEW_TIME))
+        );
     }
 
     @Test

--- a/backend/src/test/java/com/woowacourse/ternoko/acceptance/MemberAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/ternoko/acceptance/MemberAcceptanceTest.java
@@ -1,16 +1,29 @@
 package com.woowacourse.ternoko.acceptance;
 
+import static com.woowacourse.ternoko.availabledatetime.domain.AvailableDateTimeStatus.OPEN;
+import static com.woowacourse.ternoko.availabledatetime.domain.AvailableDateTimeStatus.USED;
+import static com.woowacourse.ternoko.fixture.CoachAvailableTimeFixture.FIRST_TIME;
 import static com.woowacourse.ternoko.fixture.CoachAvailableTimeFixture.MONTH_REQUEST;
 import static com.woowacourse.ternoko.fixture.CoachAvailableTimeFixture.NOW;
+import static com.woowacourse.ternoko.fixture.CoachAvailableTimeFixture.NOW_PLUS_2_DAYS;
+import static com.woowacourse.ternoko.fixture.CoachAvailableTimeFixture.NOW_PLUS_3_DAYS;
+import static com.woowacourse.ternoko.fixture.CoachAvailableTimeFixture.SECOND_TIME;
+import static com.woowacourse.ternoko.fixture.CoachAvailableTimeFixture.THIRD_TIME;
 import static com.woowacourse.ternoko.fixture.MemberFixture.COACH3;
 import static com.woowacourse.ternoko.fixture.MemberFixture.CREW1;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.woowacourse.ternoko.availabledatetime.dto.AvailableDateTimeRequest;
+import com.woowacourse.ternoko.availabledatetime.dto.AvailableDateTimeResponse;
+import com.woowacourse.ternoko.availabledatetime.dto.AvailableDateTimeSummaryRequest;
 import com.woowacourse.ternoko.availabledatetime.dto.AvailableDateTimesResponse;
+import com.woowacourse.ternoko.dto.CalendarRequest;
 import com.woowacourse.ternoko.dto.CoachesResponse;
 import io.restassured.http.Header;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import java.time.LocalDateTime;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -47,5 +60,43 @@ class MemberAcceptanceTest extends AcceptanceTest {
         // then
         assertThat(response.getCalendarTimes())
                 .hasSize(9);
+    }
+
+    @Test
+    @DisplayName("크루가 자신이 신청한 interview를 수정할 때 코치의 면담 가능 시간을 조회한다. - 해당 인터뷰 시작시간만 USED로 반환되어야한다.")
+    void findCalendarTimesByCrew() {
+        // given
+        putAvailableTimes();
+        final ExtractableResponse<Response> interviewResponse = createInterview(CREW1.getId(), COACH3.getId(),
+                LocalDateTime.of(NOW_PLUS_2_DAYS, FIRST_TIME));
+        final Long interviewId = parseLocationHeader(interviewResponse, "/api/interviews/");
+        createInterview(CREW1.getId(), COACH3.getId(), LocalDateTime.of(NOW_PLUS_2_DAYS, SECOND_TIME));
+
+        // when
+        final Header crewHeader = generateHeader(CREW1.getId());
+        final ExtractableResponse<Response> calendarResponse = get(
+                "/api/interviews/" + interviewId + "/calendar/times?"
+                        + "coachId=" + COACH3.getId()
+                        + "&year=" + NOW.getYear()
+                        + "&month=" + NOW.getMonthValue(),
+                crewHeader);
+        final AvailableDateTimesResponse response = calendarResponse.body().as(AvailableDateTimesResponse.class);
+
+        // then
+        final List<AvailableDateTimeResponse> actual = response.getCalendarTimes();
+        assertThat(actual).hasSize(3)
+                .containsExactly(new AvailableDateTimeResponse(LocalDateTime.of(NOW_PLUS_2_DAYS, FIRST_TIME), USED),
+                        new AvailableDateTimeResponse(LocalDateTime.of(NOW_PLUS_2_DAYS, THIRD_TIME), OPEN),
+                        new AvailableDateTimeResponse(LocalDateTime.of(NOW_PLUS_3_DAYS, FIRST_TIME), OPEN));
+    }
+
+    private void putAvailableTimes() {
+        final List<AvailableDateTimeSummaryRequest> inputTimes = List.of(
+                new AvailableDateTimeSummaryRequest(LocalDateTime.of(NOW_PLUS_2_DAYS, FIRST_TIME), OPEN),
+                new AvailableDateTimeSummaryRequest(LocalDateTime.of(NOW_PLUS_2_DAYS, SECOND_TIME), OPEN),
+                new AvailableDateTimeSummaryRequest(LocalDateTime.of(NOW_PLUS_2_DAYS, THIRD_TIME), OPEN),
+                new AvailableDateTimeSummaryRequest(LocalDateTime.of(NOW_PLUS_3_DAYS, FIRST_TIME), OPEN));
+        final AvailableDateTimeRequest afterTwoDays = new AvailableDateTimeRequest(NOW.getYear(), NOW.getMonthValue(), inputTimes);
+        put("/api/calendar/times", generateHeader(COACH3), new CalendarRequest(List.of(afterTwoDays)));
     }
 }

--- a/backend/src/test/java/com/woowacourse/ternoko/acceptance/MemberAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/ternoko/acceptance/MemberAcceptanceTest.java
@@ -67,13 +67,13 @@ class MemberAcceptanceTest extends AcceptanceTest {
     void findCalendarTimesByCrew() {
         // given
         putAvailableTimes();
-        final ExtractableResponse<Response> interviewResponse = createInterview(CREW1.getId(), COACH3.getId(),
+        final ExtractableResponse<Response> interviewResponse = createInterview(CREW1, COACH3.getId(),
                 LocalDateTime.of(NOW_PLUS_2_DAYS, FIRST_TIME));
         final Long interviewId = parseLocationHeader(interviewResponse, "/api/interviews/");
-        createInterview(CREW1.getId(), COACH3.getId(), LocalDateTime.of(NOW_PLUS_2_DAYS, SECOND_TIME));
+        createInterview(CREW1, COACH3.getId(), LocalDateTime.of(NOW_PLUS_2_DAYS, SECOND_TIME));
 
         // when
-        final Header crewHeader = generateHeader(CREW1.getId());
+        final Header crewHeader = generateHeader(CREW1);
         final ExtractableResponse<Response> calendarResponse = get(
                 "/api/interviews/" + interviewId + "/calendar/times?"
                         + "coachId=" + COACH3.getId()

--- a/backend/src/test/java/com/woowacourse/ternoko/api/CoachControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/ternoko/api/CoachControllerTest.java
@@ -64,6 +64,24 @@ public class CoachControllerTest extends ControllerTest {
     }
 
     @Test
+    @DisplayName("크루 - 면담 수정시 면담 가능 시간 목록을 조회한다.")
+    void findCalendarTimesByInterviewId() throws Exception {
+        // given
+        createCalendarTimes(COACH1.getId());
+        final Long interviewId = createInterview(CREW1.getId());
+
+        // when, then
+        mockMvc.perform(MockMvcRequestBuilders
+                        .get("/api/interviews/{interviewId}/calendar/times", interviewId)
+                        .header(AUTHORIZATION, BEARER_TYPE + jwtProvider.createToken(String.valueOf(CREW1.getId())))
+                        .queryParam("coachId", String.valueOf(COACH1.getId()))
+                        .queryParam("year", String.valueOf(NOW_MONTH_REQUEST.getYear()))
+                        .queryParam("month", String.valueOf(NOW_MONTH_REQUEST.getMonth())))
+                .andExpect(status().isOk())
+                .andDo(restDocs.document());
+    }
+
+    @Test
     @DisplayName("코치 - 내 정보를 조회한다.")
     void findCoach() throws Exception {
         // given, when, then

--- a/backend/src/test/java/com/woowacourse/ternoko/api/CoachControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/ternoko/api/CoachControllerTest.java
@@ -67,8 +67,8 @@ public class CoachControllerTest extends ControllerTest {
     @DisplayName("크루 - 면담 수정시 면담 가능 시간 목록을 조회한다.")
     void findCalendarTimesByInterviewId() throws Exception {
         // given
-        createCalendarTimes(COACH1.getId());
-        final Long interviewId = createInterview(CREW1.getId());
+        createCalendarTimes(COACH1);
+        final Long interviewId = createInterview(CREW1);
 
         // when, then
         mockMvc.perform(MockMvcRequestBuilders

--- a/backend/src/test/java/com/woowacourse/ternoko/availabledatetime/domain/AvailableDateTimeRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/ternoko/availabledatetime/domain/AvailableDateTimeRepositoryTest.java
@@ -52,13 +52,13 @@ class AvailableDateTimeRepositoryTest {
 
         // then
         assertThat(times).hasSize(2)
-                .containsExactly(new AvailableDateTime(startDateTime.getId(), COACH1, startTime, USED),
-                        new AvailableDateTime(availableDateTime.getId(), COACH1, availableTime, OPEN));
+                .containsExactly(new AvailableDateTime(startDateTime.getId(), COACH1.getId(), startTime, USED),
+                        new AvailableDateTime(availableDateTime.getId(), COACH1.getId(), availableTime, OPEN));
 
     }
 
     private AvailableDateTime saveAvailableTime(final LocalDateTime startTime) {
-        return availableDateTimeRepository.save(new AvailableDateTime(COACH1, startTime, OPEN));
+        return availableDateTimeRepository.save(new AvailableDateTime(COACH1.getId(), startTime, OPEN));
     }
 
     private Long saveInterview(final LocalDateTime startTime) {

--- a/backend/src/test/java/com/woowacourse/ternoko/availabledatetime/domain/AvailableDateTimeRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/ternoko/availabledatetime/domain/AvailableDateTimeRepositoryTest.java
@@ -1,0 +1,73 @@
+package com.woowacourse.ternoko.availabledatetime.domain;
+
+import static com.woowacourse.ternoko.availabledatetime.domain.AvailableDateTimeStatus.OPEN;
+import static com.woowacourse.ternoko.availabledatetime.domain.AvailableDateTimeStatus.USED;
+import static com.woowacourse.ternoko.fixture.CoachAvailableTimeFixture.FIRST_TIME;
+import static com.woowacourse.ternoko.fixture.CoachAvailableTimeFixture.NOW_PLUS_1_MONTH;
+import static com.woowacourse.ternoko.fixture.CoachAvailableTimeFixture.SECOND_TIME;
+import static com.woowacourse.ternoko.fixture.CoachAvailableTimeFixture.THIRD_TIME;
+import static com.woowacourse.ternoko.fixture.MemberFixture.COACH1;
+import static com.woowacourse.ternoko.fixture.MemberFixture.CREW1;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.woowacourse.ternoko.interview.domain.Interview;
+import com.woowacourse.ternoko.interview.domain.InterviewRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+class AvailableDateTimeRepositoryTest {
+
+    @Autowired
+    private AvailableDateTimeRepository availableDateTimeRepository;
+
+    @Autowired
+    private InterviewRepository interviewRepository;
+
+    @Test
+    @DisplayName("해당 코치의 면담가능한 시간과 interview startTime이 포함된 정렬된 AvailableTime List를 반환해야 한다.")
+    void findAvailableDateTimesByCoachIdAndInterviewId() {
+        // given
+        final LocalDateTime startTime = LocalDateTime.of(NOW_PLUS_1_MONTH, FIRST_TIME);
+        final LocalDateTime reservedTime = LocalDateTime.of(NOW_PLUS_1_MONTH, SECOND_TIME);
+        final LocalDateTime availableTime = LocalDateTime.of(NOW_PLUS_1_MONTH, THIRD_TIME);
+
+        final AvailableDateTime availableDateTime = saveAvailableTime(availableTime);
+        final AvailableDateTime startDateTime = saveAvailableTime(startTime);
+        startDateTime.changeStatus(USED);
+        final AvailableDateTime reservedDateTime = saveAvailableTime(reservedTime);
+        reservedDateTime.changeStatus(USED);
+
+        // when
+        final Long interviewId = saveInterview(startTime);
+        final List<AvailableDateTime> times = availableDateTimeRepository
+                .findAvailableDateTimesByCoachIdAndInterviewId(interviewId,
+                COACH1.getId(),
+                NOW_PLUS_1_MONTH.getYear(),
+                NOW_PLUS_1_MONTH.getMonthValue());
+
+        // then
+        assertThat(times).hasSize(2)
+                .containsExactly(new AvailableDateTime(startDateTime.getId(), COACH1, startTime, USED),
+                        new AvailableDateTime(availableDateTime.getId(), COACH1, availableTime, OPEN));
+
+    }
+
+    private AvailableDateTime saveAvailableTime(final LocalDateTime startTime) {
+        return availableDateTimeRepository.save(new AvailableDateTime(COACH1, startTime, OPEN));
+    }
+
+    private Long saveInterview(final LocalDateTime startTime) {
+        final Interview interview = interviewRepository.save(new Interview(
+                startTime,
+                startTime.plusMinutes(30),
+                COACH1,
+                CREW1
+        ));
+        return interview.getId();
+    }
+}

--- a/backend/src/test/java/com/woowacourse/ternoko/service/CoachServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/ternoko/service/CoachServiceTest.java
@@ -129,6 +129,25 @@ public class CoachServiceTest {
     void findAvailableDateTimesByCoachId() {
         // given
         coachService.putAvailableDateTimesByCoachId(COACH3.getId(), MONTHS_REQUEST);
+
+        // when
+        final List<AvailableDateTime> availableDateTimes = coachService
+                .findAvailableDateTimesByCoachId(COACH3.getId(), NOW_PLUS_1_MONTH.getYear(),
+                        NOW_PLUS_1_MONTH.getMonthValue());
+
+        // then
+        assertThat(availableDateTimes.stream()
+                .map(AvailableDateTime::getLocalDateTime)
+                .collect(Collectors.toList()))
+                .hasSize(3);
+    }
+
+    @Test
+    @DisplayName("크루 면담 수정시 코치의 면담 가능 시간을 조회한다.")
+    void findAvailableDateTimesByCoachIdAndInterviewId() {
+        // given
+        coachService.putAvailableDateTimesByCoachId(COACH3.getId(), MONTHS_REQUEST);
+
         // when
         final List<AvailableDateTime> availableDateTimes = coachService
                 .findAvailableDateTimesByCoachId(COACH3.getId(), NOW_PLUS_1_MONTH.getYear(),


### PR DESCRIPTION
### Issues
- [ ] #212

### 논의사항
- 해당 이슈 들어가셔서 어떤 API인지 이해하고 오시는 것이 좋아요.
- 새로운 API가 필요해졌는데 사실 특정 인터뷰에 종속된 면담가능한 시간이어서 interviews 계층에 넣었습니다.
   - `GET /api/interviews/{interviewId}/calendar/times?coachId={1}&year={year}&month={month} `
- 그런데 사실 면담가능한시간 조회는 CoachController, CoachService에 존재해서 메서드들은 일단 그쪽에 넣었습니다.;
- 나중에는 AvailableDatTImeService 로도 분리를 고려해봐야할 것 같아요
- 서브쿼리로 interview id의 localDateTime을 가져와 포함시켰습니다.
- 테스트코드 열심히 짜봤는데 복잡하더라구요! 가독성이 괜찮은지 봐주세요.

close #212 


