### PR TITLE
[BE] feat: 로그 전략 도입 및 환경별 적용

### DIFF
--- a/backend/src/main/java/com/woowacourse/ternoko/common/AuthInterceptor.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/common/AuthInterceptor.java
@@ -8,13 +8,15 @@ import com.woowacourse.ternoko.service.AuthService;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Component;
 import org.springframework.web.cors.CorsUtils;
 import org.springframework.web.servlet.HandlerInterceptor;
 
+@Component
 @AllArgsConstructor
 public class AuthInterceptor implements HandlerInterceptor {
 
-    private AuthService authService;
+    private final AuthService authService;
 
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {

--- a/backend/src/main/java/com/woowacourse/ternoko/common/exception/ExceptionResponse.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/common/exception/ExceptionResponse.java
@@ -11,4 +11,8 @@ import lombok.NoArgsConstructor;
 public class ExceptionResponse {
     private int code;
     private String message;
+
+    public static ExceptionResponse from(final CommonException e){
+        return new ExceptionResponse(e.getCode().value(), e.getMessage());
+    }
 }

--- a/backend/src/main/java/com/woowacourse/ternoko/common/exception/ExceptionResponse.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/common/exception/ExceptionResponse.java
@@ -9,10 +9,11 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class ExceptionResponse {
+
     private int code;
     private String message;
 
-    public static ExceptionResponse from(final CommonException e){
+    public static ExceptionResponse from(final CommonException e) {
         return new ExceptionResponse(e.getCode().value(), e.getMessage());
     }
 }

--- a/backend/src/main/java/com/woowacourse/ternoko/common/exception/advice/GlobalControllerAdvice.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/common/exception/advice/GlobalControllerAdvice.java
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.woowacourse.ternoko.common.exception.CommonException;
 import com.woowacourse.ternoko.common.exception.ExceptionResponse;
 import java.io.IOException;
-import java.sql.SQLException;
 import javax.servlet.http.HttpServletRequest;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/backend/src/main/java/com/woowacourse/ternoko/common/exception/advice/GlobalControllerAdvice.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/common/exception/advice/GlobalControllerAdvice.java
@@ -10,6 +10,7 @@ import java.sql.SQLException;
 import javax.servlet.http.HttpServletRequest;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataAccessException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.util.StringUtils;
@@ -28,14 +29,15 @@ public class GlobalControllerAdvice extends ResponseEntityExceptionHandler {
     private final ObjectMapper objectMapper;
 
     @ExceptionHandler(CommonException.class)
-    public ResponseEntity<ExceptionResponse> commonExceptionHandler(HttpServletRequest request, CommonException e)
+    public ResponseEntity<ExceptionResponse> commonExceptionHandler(final HttpServletRequest request,
+                                                                    final CommonException e)
             throws IOException {
         final ContentCachingRequestWrapper cachingRequest = (ContentCachingRequestWrapper) request;
         printFailedLog(request, e, cachingRequest);
         return ResponseEntity.status(e.getCode()).body(ExceptionResponse.from(e));
     }
 
-    @ExceptionHandler(SQLException.class)
+    @ExceptionHandler(DataAccessException.class)
     public ResponseEntity<ExceptionResponse> sqlExceptionHandler() {
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                 .body(new ExceptionResponse(HttpStatus.INTERNAL_SERVER_ERROR.value(),
@@ -43,7 +45,8 @@ public class GlobalControllerAdvice extends ResponseEntityExceptionHandler {
     }
 
     @ExceptionHandler(RuntimeException.class)
-    public ResponseEntity<ExceptionResponse> unhandledExceptionHandler(HttpServletRequest request) throws IOException {
+    public ResponseEntity<ExceptionResponse> unhandledExceptionHandler(final HttpServletRequest request)
+            throws IOException {
         final ContentCachingRequestWrapper cachingRequest = (ContentCachingRequestWrapper) request;
         log.info(FAILED_LOGGING_FORM,
                 request.getMethod(),
@@ -58,7 +61,9 @@ public class GlobalControllerAdvice extends ResponseEntityExceptionHandler {
         ));
     }
 
-    private void printFailedLog(HttpServletRequest request, CommonException e, ContentCachingRequestWrapper cachingRequest)
+    private void printFailedLog(final HttpServletRequest request,
+                                final CommonException e,
+                                final ContentCachingRequestWrapper cachingRequest)
             throws IOException {
         log.info(FAILED_LOGGING_FORM,
                 request.getMethod(),

--- a/backend/src/main/java/com/woowacourse/ternoko/common/exception/advice/GlobalControllerAdvice.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/common/exception/advice/GlobalControllerAdvice.java
@@ -4,26 +4,42 @@ import com.woowacourse.ternoko.common.exception.BadRequestException;
 import com.woowacourse.ternoko.common.exception.ExceptionResponse;
 import com.woowacourse.ternoko.common.exception.UnauthorizedException;
 import java.sql.SQLException;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+@Slf4j
 @RestControllerAdvice
 public class GlobalControllerAdvice {
 
+    private static final String LOG_FORM =
+            " \n CODE : {} "
+            + "\n MESSAGE : {}";
+    private static final String UNHANDLE_EXCEPTION_MESSAGE = "유효하지 않은 요청입니다.";
+
+    @ExceptionHandler(RuntimeException.class)
+    public ResponseEntity unhandleExceptionHandler(){
+        log.error(LOG_FORM, HttpStatus.INTERNAL_SERVER_ERROR.value(), UNHANDLE_EXCEPTION_MESSAGE);
+        return ResponseEntity.internalServerError().body(UNHANDLE_EXCEPTION_MESSAGE);
+    }
+
     @ExceptionHandler(BadRequestException.class)
     public ResponseEntity<ExceptionResponse> badRequestHandler(BadRequestException e) {
+        log.warn(LOG_FORM, e.getCode(), e.getMessage());
         return ResponseEntity.status(e.getCode()).body(new ExceptionResponse(e.getCode().value(), e.getMessage()));
     }
 
     @ExceptionHandler(UnauthorizedException.class)
     public ResponseEntity<ExceptionResponse> unauthorizedHandler(UnauthorizedException e) {
+        log.warn(LOG_FORM, e.getCode(), e.getMessage());
         return ResponseEntity.status(e.getCode()).body(new ExceptionResponse(e.getCode().value(), e.getMessage()));
     }
 
     @ExceptionHandler(SQLException.class)
     public ResponseEntity<ExceptionResponse> sqlExceptionHandler(SQLException e) {
+        log.warn(LOG_FORM, HttpStatus.INTERNAL_SERVER_ERROR.value(), "SQL exception이 발생했습니다.");
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                 .body(new ExceptionResponse(HttpStatus.INTERNAL_SERVER_ERROR.value(),
                         "SQL exception이 발생했습니다."));

--- a/backend/src/main/java/com/woowacourse/ternoko/common/exception/advice/GlobalControllerAdvice.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/common/exception/advice/GlobalControllerAdvice.java
@@ -37,7 +37,7 @@ public class GlobalControllerAdvice extends ResponseEntityExceptionHandler {
         return ResponseEntity.status(e.getCode()).body(ExceptionResponse.from(e));
     }
 
-    @ExceptionHandler(DataAccessException.class)
+    @ExceptionHandler(SQLException.class)
     public ResponseEntity<ExceptionResponse> sqlExceptionHandler() {
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                 .body(new ExceptionResponse(HttpStatus.INTERNAL_SERVER_ERROR.value(),

--- a/backend/src/main/java/com/woowacourse/ternoko/common/exception/advice/GlobalControllerAdvice.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/common/exception/advice/GlobalControllerAdvice.java
@@ -37,7 +37,7 @@ public class GlobalControllerAdvice extends ResponseEntityExceptionHandler {
         return ResponseEntity.status(e.getCode()).body(ExceptionResponse.from(e));
     }
 
-    @ExceptionHandler(SQLException.class)
+    @ExceptionHandler(DataAccessException.class)
     public ResponseEntity<ExceptionResponse> sqlExceptionHandler() {
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                 .body(new ExceptionResponse(HttpStatus.INTERNAL_SERVER_ERROR.value(),

--- a/backend/src/main/java/com/woowacourse/ternoko/common/log/CustomLoggingFilter.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/common/log/CustomLoggingFilter.java
@@ -5,6 +5,7 @@ import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import org.jetbrains.annotations.NotNull;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 import org.springframework.web.util.ContentCachingRequestWrapper;
@@ -13,7 +14,9 @@ import org.springframework.web.util.ContentCachingRequestWrapper;
 public class CustomLoggingFilter extends OncePerRequestFilter {
 
     @Override
-    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+    protected void doFilterInternal(@NotNull final HttpServletRequest request,
+                                    @NotNull final HttpServletResponse response,
+                                    final FilterChain filterChain)
             throws ServletException, IOException {
         ContentCachingRequestWrapper wrappingRequest = new ContentCachingRequestWrapper(request);
 

--- a/backend/src/main/java/com/woowacourse/ternoko/common/log/CustomLoggingFilter.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/common/log/CustomLoggingFilter.java
@@ -1,0 +1,22 @@
+package com.woowacourse.ternoko.common.log;
+
+import java.io.IOException;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.util.ContentCachingRequestWrapper;
+
+@Component
+public class CustomLoggingFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        ContentCachingRequestWrapper wrappingRequest = new ContentCachingRequestWrapper(request);
+
+        filterChain.doFilter(wrappingRequest, response);
+    }
+}

--- a/backend/src/main/java/com/woowacourse/ternoko/common/log/LogForm.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/common/log/LogForm.java
@@ -3,13 +3,13 @@ package com.woowacourse.ternoko.common.log;
 public class LogForm {
 
     public static final String SUCCESS_LOGGING_FORM =
-            "\n HTTP Method : {} " +
-            "\n Request URI : {} " +
-            "\n AccessToken is exist : {} " +
-            "\n Request Body : {}";
+            "\n HTTP Method : {} "
+            + "\n Request URI : {} "
+            + "\n AccessToken is exist : {} "
+            + "\n Request Body : {}";
 
     public static final String FAILED_LOGGING_FORM =
-            SUCCESS_LOGGING_FORM +
-            "\n CODE : {} " +
-            "\n MESSAGE : {}";
+            SUCCESS_LOGGING_FORM
+            + "\n CODE : {} "
+            + "\n MESSAGE : {}";
 }

--- a/backend/src/main/java/com/woowacourse/ternoko/common/log/LogForm.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/common/log/LogForm.java
@@ -1,0 +1,15 @@
+package com.woowacourse.ternoko.common.log;
+
+public class LogForm {
+
+    public static final String SUCCESS_LOGGING_FORM =
+            "\n HTTP Method : {} " +
+            "\n Request URI : {} " +
+            "\n AccessToken is exist : {} " +
+            "\n Request Body : {}";
+
+    public static final String FAILED_LOGGING_FORM =
+            SUCCESS_LOGGING_FORM +
+            "\n CODE : {} " +
+            "\n MESSAGE : {}";
+}

--- a/backend/src/main/java/com/woowacourse/ternoko/common/log/LogForm.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/common/log/LogForm.java
@@ -2,14 +2,16 @@ package com.woowacourse.ternoko.common.log;
 
 public class LogForm {
 
+    private static final String NEWLINE = System.lineSeparator();
+
     public static final String SUCCESS_LOGGING_FORM =
-            "\n HTTP Method : {} "
-            + "\n Request URI : {} "
-            + "\n AccessToken is exist : {} "
-            + "\n Request Body : {}";
+            NEWLINE + "HTTP Method : {} "
+            + NEWLINE +"Request URI : {} "
+            + NEWLINE +"AccessToken is exist : {} "
+            + NEWLINE +"Request Body : {}";
 
     public static final String FAILED_LOGGING_FORM =
             SUCCESS_LOGGING_FORM
-            + "\n CODE : {} "
-            + "\n MESSAGE : {}";
+            + NEWLINE + "CODE : {} "
+            + NEWLINE + "MESSAGE : {}";
 }

--- a/backend/src/main/java/com/woowacourse/ternoko/common/log/LogForm.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/common/log/LogForm.java
@@ -6,9 +6,9 @@ public class LogForm {
 
     public static final String SUCCESS_LOGGING_FORM =
             NEWLINE + "HTTP Method : {} "
-            + NEWLINE +"Request URI : {} "
-            + NEWLINE +"AccessToken is exist : {} "
-            + NEWLINE +"Request Body : {}";
+            + NEWLINE + "Request URI : {} "
+            + NEWLINE + "AccessToken is exist : {} "
+            + NEWLINE + "Request Body : {}";
 
     public static final String FAILED_LOGGING_FORM =
             SUCCESS_LOGGING_FORM

--- a/backend/src/main/java/com/woowacourse/ternoko/common/log/LogInterceptor.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/common/log/LogInterceptor.java
@@ -1,0 +1,40 @@
+package com.woowacourse.ternoko.common.log;
+
+import static com.woowacourse.ternoko.common.log.LogForm.SUCCESS_LOGGING_FORM;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.util.ContentCachingRequestWrapper;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class LogInterceptor implements HandlerInterceptor {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void afterCompletion(HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex)
+            throws Exception {
+        if (isSuccess(response.getStatus())) {
+            final ContentCachingRequestWrapper cachingRequest = (ContentCachingRequestWrapper) request;
+
+            log.info(SUCCESS_LOGGING_FORM, request.getMethod(),
+                    request.getRequestURI(),
+                    StringUtils.hasText(request.getHeader("Authorization")),
+                    objectMapper.readTree(cachingRequest.getContentAsByteArray()));
+        }
+    }
+
+    private boolean isSuccess(int responseStatus) {
+        return !HttpStatus.valueOf(responseStatus).is4xxClientError() && !HttpStatus.valueOf(responseStatus)
+                .is5xxServerError();
+    }
+}

--- a/backend/src/main/java/com/woowacourse/ternoko/common/log/LogInterceptor.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/common/log/LogInterceptor.java
@@ -7,6 +7,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.jetbrains.annotations.NotNull;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
@@ -21,7 +22,10 @@ public class LogInterceptor implements HandlerInterceptor {
     private final ObjectMapper objectMapper;
 
     @Override
-    public void afterCompletion(HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex)
+    public void afterCompletion(@NotNull final HttpServletRequest request,
+                                final HttpServletResponse response,
+                                @NotNull final Object handler,
+                                final Exception ex)
             throws Exception {
         if (isSuccess(response.getStatus())) {
             final ContentCachingRequestWrapper cachingRequest = (ContentCachingRequestWrapper) request;

--- a/backend/src/main/java/com/woowacourse/ternoko/config/AuthenticationPrincipalConfig.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/config/AuthenticationPrincipalConfig.java
@@ -23,7 +23,7 @@ public class AuthenticationPrincipalConfig implements WebMvcConfigurer {
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(authInterceptor)
-                .addPathPatterns("/api/reservations/**")
+                .addPathPatterns("/api/interviews/**")
                 .addPathPatterns("/api/calendar/times/**")
                 .addPathPatterns("/api/schedules/**")
                 .addPathPatterns("/api/coaches/**")

--- a/backend/src/main/java/com/woowacourse/ternoko/config/AuthenticationPrincipalConfig.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/config/AuthenticationPrincipalConfig.java
@@ -2,7 +2,6 @@ package com.woowacourse.ternoko.config;
 
 import com.woowacourse.ternoko.common.AuthInterceptor;
 import com.woowacourse.ternoko.common.JwtProvider;
-import com.woowacourse.ternoko.service.AuthService;
 import java.util.List;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -13,18 +12,18 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 public class AuthenticationPrincipalConfig implements WebMvcConfigurer {
 
     private final JwtProvider jwtTokenProvider;
-    private final AuthService authService;
+    private final AuthInterceptor authInterceptor;
 
     public AuthenticationPrincipalConfig(final JwtProvider jwtProvider,
-                                         AuthService authService) {
+                                         final AuthInterceptor authInterceptor) {
         this.jwtTokenProvider = jwtProvider;
-        this.authService = authService;
+        this.authInterceptor = authInterceptor;
     }
 
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
-        registry.addInterceptor(new AuthInterceptor(authService))
-                .addPathPatterns("/api/interviews/**")
+        registry.addInterceptor(authInterceptor)
+                .addPathPatterns("/api/reservations/**")
                 .addPathPatterns("/api/calendar/times/**")
                 .addPathPatterns("/api/schedules/**")
                 .addPathPatterns("/api/coaches/**")
@@ -39,10 +38,5 @@ public class AuthenticationPrincipalConfig implements WebMvcConfigurer {
     @Bean
     public AuthenticationPrincipalArgumentResolver createAuthenticationPrincipalArgumentResolver() {
         return new AuthenticationPrincipalArgumentResolver(jwtTokenProvider);
-    }
-
-    @Bean
-    public AuthInterceptor authInterceptor() {
-        return new AuthInterceptor(authService);
     }
 }

--- a/backend/src/main/java/com/woowacourse/ternoko/config/WebConfig.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/config/WebConfig.java
@@ -10,15 +10,13 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
 
-    private final LogInterceptor logInterceptor;
-
     public static final String ALLOWED_METHOD_NAMES = "GET,HEAD,POST,PUT,DELETE,TRACE,OPTIONS,PATCH";
 
-    public WebConfig(LogInterceptor logInterceptor) {
+    private final LogInterceptor logInterceptor;
+
+    public WebConfig(final LogInterceptor logInterceptor) {
         this.logInterceptor = logInterceptor;
     }
-
-
 
     @Override
     public void addCorsMappings(final CorsRegistry registry) {
@@ -28,7 +26,7 @@ public class WebConfig implements WebMvcConfigurer {
     }
 
     @Override
-    public void addInterceptors(InterceptorRegistry registry) {
+    public void addInterceptors(final InterceptorRegistry registry) {
         registry.addInterceptor(logInterceptor)
             .addPathPatterns("/api/**");
     }

--- a/backend/src/main/java/com/woowacourse/ternoko/config/WebConfig.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/config/WebConfig.java
@@ -1,18 +1,35 @@
 package com.woowacourse.ternoko.config;
 
+import com.woowacourse.ternoko.common.log.LogInterceptor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpHeaders;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
+
+    private final LogInterceptor logInterceptor;
+
     public static final String ALLOWED_METHOD_NAMES = "GET,HEAD,POST,PUT,DELETE,TRACE,OPTIONS,PATCH";
+
+    public WebConfig(LogInterceptor logInterceptor) {
+        this.logInterceptor = logInterceptor;
+    }
+
+
 
     @Override
     public void addCorsMappings(final CorsRegistry registry) {
         registry.addMapping("/api/**")
                 .allowedMethods(ALLOWED_METHOD_NAMES.split(","))
                 .exposedHeaders(HttpHeaders.LOCATION);
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(logInterceptor)
+            .addPathPatterns("/api/**");
     }
 }

--- a/backend/src/main/resources/application-local.yml
+++ b/backend/src/main/resources/application-local.yml
@@ -25,7 +25,7 @@ spring:
   datasource:
     url: jdbc:mysql://localhost:3306/ternoko?serverTimezone=Asia/Seoul
     username: root
-    password: Keyduck2021^^
+    password:
 
 slack:
   clientId: '3756998338916.3821665111344'

--- a/backend/src/main/resources/application-local.yml
+++ b/backend/src/main/resources/application-local.yml
@@ -25,7 +25,7 @@ spring:
   datasource:
     url: jdbc:mysql://localhost:3306/ternoko?serverTimezone=Asia/Seoul
     username: root
-    password:
+    password: Keyduck2021^^
 
 slack:
   clientId: '3756998338916.3821665111344'

--- a/backend/src/main/resources/log4j2-local.xml
+++ b/backend/src/main/resources/log4j2-local.xml
@@ -20,7 +20,11 @@
     <!--Log가 찍힐 대상 설정.-->
     <Loggers>
         <!-- 스프링 프레임워크에서 찍는건 level을 info로 설정 -->
-        <logger name="org.springframework" level="info" additivity="false">
+        <logger name="org.springframework." level="info" additivity="false">
+            <AppenderRef ref="console"/>
+        </logger>
+
+        <logger name="com.woowacourse.ternoko" level="debug" additivity="false">
             <AppenderRef ref="console"/>
         </logger>
 
@@ -40,6 +44,7 @@
         </logger>
 
         <!-- ROOT logger-->
-        <Root level="info"></Root>
+        <Root level="debug"></Root>
+
     </Loggers>
 </Configuration>

--- a/backend/src/main/resources/log4j2-local.xml
+++ b/backend/src/main/resources/log4j2-local.xml
@@ -15,73 +15,21 @@
         <Console name="console" target="SYSTEM_OUT">
             <PatternLayout pattern="${layoutPattern}" disableAnsi="false"/>
         </Console>
-        <!--ConsoleAppender, RollingFileAppneder -->
-        <RollingFile name="file"
-                     fileName="logs/${logFileName}.log"
-                     filePattern="logs/${logFileName}.%d{yyyy-MM-dd-hh}.log">
-            <PatternLayout pattern="${fileLayout}"/>
-            <Policies>
-                <TimeBasedTriggeringPolicy
-                        modulate="true"
-                        interval="1"/><!-- 시간별 로그 파일 생성-->
-            </Policies>
-            <DefaultRolloverStrategy max="5" fileIndex="min"> <!-- 롤링 파일 5개 까지 생성 -->
-                <Delete basePath="/logs" maxDepth="3">
-                    <IfLastModified age="3d"/>
-                </Delete>
-            </DefaultRolloverStrategy>
-        </RollingFile>
-
-        <RollingFile name="sql_log"
-                     fileName="logs/sql.log"
-                     filePattern="logs/sql.%d{yyyy-MM-dd-hh}.log">
-            <PatternLayout pattern="${fileLayout}"/>
-            <Policies>
-                <TimeBasedTriggeringPolicy
-                        modulate="true"
-                        interval="1"/><!-- 시간별 로그 파일 생성-->
-            </Policies>
-            <DefaultRolloverStrategy max="5" fileIndex="min"> <!-- 롤링 파일 5개 까지 생성 -->
-                <Delete basePath="/logs" maxDepth="3">
-                    <IfLastModified age="3d"/>
-                </Delete>
-            </DefaultRolloverStrategy>
-        </RollingFile>
-
-        <RollingFile name="sql_basicBinder_log"
-                     fileName="logs/sql_basicBinder.log"
-                     filePattern="logs/sql_basicBinder.%d{yyyy-MM-dd-hh}.log">
-            <PatternLayout pattern="${fileLayout}"/>
-            <Policies>
-                <TimeBasedTriggeringPolicy
-                        modulate="true"
-                        interval="1"/><!-- 시간별 로그 파일 생성-->
-            </Policies>
-            <DefaultRolloverStrategy max="5" fileIndex="min"> <!-- 롤링 파일 5개 까지 생성 -->
-                <Delete basePath="/logs" maxDepth="3">
-                    <IfLastModified age="3d"/>
-                </Delete>
-            </DefaultRolloverStrategy>
-        </RollingFile>
-
-
     </Appenders>
-
     <!--TRACE > DEBUG > INFO > WARN > ERROR > FATAL -->
     <!--Log가 찍힐 대상 설정.-->
     <Loggers>
         <!-- 스프링 프레임워크에서 찍는건 level을 info로 설정 -->
         <logger name="org.springframework" level="info" additivity="false">
             <AppenderRef ref="console"/>
-            <AppenderRef ref="file"/>
         </logger>
 
-        <!-- sql 표시 설정 debug 레벨부터 sql log 찍힘-->
+        <!-- debug 레벨부터 sql log 찍힘-->
         <logger name="org.hibernate.SQL" level="debug" additivity="false">
             <AppenderRef ref="console"/>
         </logger>
 
-        <!-- sql 파라미터 표시 설정 trace 레벨부터 binding parameter 찍힘-->
+        <!-- binding parameter 찍힘-->
         <logger name="org.hibernate.type.descriptor.sql.BasicBinder" level="trace" additivity="false">
             <AppenderRef ref="console"/>
         </logger>

--- a/backend/src/main/resources/log4j2-local.xml
+++ b/backend/src/main/resources/log4j2-local.xml
@@ -20,7 +20,7 @@
     <!--Log가 찍힐 대상 설정.-->
     <Loggers>
         <!-- 스프링 프레임워크에서 찍는건 level을 info로 설정 -->
-        <logger name="org.springframework." level="info" additivity="false">
+        <logger name="org.springframework" level="info" additivity="false">
             <AppenderRef ref="console"/>
         </logger>
 


### PR DESCRIPTION
### Issues
- [x] #178 

### 논의사항
1. 로깅 전략 변경
여러가지 메소드를 타다가 발생하는 예외를 잡기위해선 이전 요청또한 파악할 수 있어야 한다고 생각되어서
기존에 말씀드렸던 것(실패한 메소드만 요청과 실패원인을 로깅한다는 전략) 과는 달리 모든 요청을 찍게끔 전략을 변경하였습니다!
이 과정에서 환경별 로그 레벨이 
prod : info
dev, local : debug 
로 변경되었습니다

2. sqlExceptionHandler() 삭제 제안
현재 ControllerAdvice에서 SQLException을 핸들링하게끔 되어있는데
제가 알기론 jpaRepository를 사용하는 경우 스프링에서 해당 Exception을 DataAccessException으로 변환해주는 것으로 알고있습니다.
DataAccessException은 RuntimeException을 상속받기 때문에 sqlExceptionHandler()를 타지않을 것이라 생각되는데요.
혹시 sqlExceptionHandler()가 따로 있었던 이유가 무엇이며, 사용되지 않는다면 삭제하는건 어떻게 생각하시나요?

+) dev 서버와 prod 서버 설정은 인스턴스에 접근해서 확인해야 하므로 출근 시 반영될 예정입니다!

close #178 


