### PR TITLE
[BE] fix: 인터뷰 테이블이 drop되지 않던 문제 해결

### DIFF
--- a/backend/src/main/resources/application-local.yml
+++ b/backend/src/main/resources/application-local.yml
@@ -19,6 +19,7 @@ spring:
       ddl-auto: create
     properties:
       hibernate:
+        dialect: org.hibernate.dialect.MySQL57Dialect
         format_sql: true
   datasource:
     url: jdbc:mysql://localhost:3306/ternoko?serverTimezone=Asia/Seoul


### PR DESCRIPTION
### Issues
- [ ] #255 

### 논의사항
- interview table이 ddl에 의해 drop이 되지 않던 문제 때문에 인터뷰들 조회가 불가능 했습니다.
   <img width="1431" alt="스크린샷 2022-08-15 17 59 52" src="https://user-images.githubusercontent.com/54317630/184606963-8b9150ed-d9ff-44f9-a6d7-95ccc68523cc.png">

- 새롭게 기능이 추가되면서 기존의 방언버전으로는 drop이 안되어서 발생하는 문제였습니다.
   - 새로운 버전의 방언으로 설정해주면 drop이 됩니다.
   - 배포서버에서는 서브모듈의 dev yml이 돌아가기 때문에 현재 커밋의 수정사항은 그냥 dev와 같이 맞춰준 용도입니다.

close #255 


