### PR TITLE
[BE] fix: 코치가 취소한 면담을 크루가 삭제할 수 없던 문제 해결

### DIFF
--- a/backend/src/main/java/com/woowacourse/ternoko/interview/presentation/InterviewController.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/interview/presentation/InterviewController.java
@@ -80,10 +80,10 @@ public class InterviewController {
     }
 
     @PatchMapping("/interviews/{interviewId}")
-    public ResponseEntity<Void> cancelInterview2(@AuthenticationPrincipal final Long coachId,
-                                                 @PathVariable final Long interviewId,
-                                                 @RequestParam final boolean onlyInterview) throws Exception {
-        final Interview interview = interviewService.cancelWithDeleteAvailableTime(coachId, interviewId, onlyInterview);
+    public ResponseEntity<Void> cancelInterview(@AuthenticationPrincipal final Long coachId,
+                                                @PathVariable final Long interviewId,
+                                                @RequestParam final boolean onlyInterview) throws Exception {
+        final Interview interview = interviewService.cancelAndDeleteAvailableTime(coachId, interviewId, onlyInterview);
         slackAlarm.sendMessage(interview, AlarmMessage.COACH_CANCEL.getMessage());
         return ResponseEntity.noContent().build();
     }

--- a/backend/src/test/java/com/woowacourse/ternoko/interview/application/InterviewServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/ternoko/interview/application/InterviewServiceTest.java
@@ -244,7 +244,7 @@ class InterviewServiceTest {
                 new InterviewRequest(COACH4.getId(), LocalDateTime.of(NOW_PLUS_3_DAYS, SECOND_TIME),
                         FORM_ITEM_REQUESTS));
 
-        interviewService.cancelWithDeleteAvailableTime(COACH4.getId(), interview.getId(), false);
+        interviewService.cancelAndDeleteAvailableTime(COACH4.getId(), interview.getId(), false);
 
         // when
         final ScheduleResponse scheduleResponses = interviewService.findAllByCoach(COACH4.getId(),
@@ -448,7 +448,7 @@ class InterviewServiceTest {
     }
 
     @Test
-    @DisplayName("면담 예약을 삭제한다.")
+    @DisplayName("크루가 면담 예약을 삭제한다.")
     void delete() {
         // given
         coachService.putAvailableDateTimesByCoachId(COACH3.getId(), MONTH_REQUEST);
@@ -457,6 +457,24 @@ class InterviewServiceTest {
                 new InterviewRequest(COACH3.getId(), LocalDateTime.of(NOW_PLUS_2_DAYS, FIRST_TIME),
                         FORM_ITEM_REQUESTS));
         // when
+        Interview updateInterview = interviewService.delete(CREW1.getId(), interview.getId());
+
+        // then
+        assertThatThrownBy(() -> interviewService.findInterviewResponseById(updateInterview.getId()))
+                .isInstanceOf(InterviewNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("크루 - 코치가 취소한 면담 예약을 삭제한다.")
+    void deleteCanceledInterview() {
+        // given
+        coachService.putAvailableDateTimesByCoachId(COACH3.getId(), MONTH_REQUEST);
+
+        final Interview interview = interviewService.create(CREW1.getId(),
+                new InterviewRequest(COACH3.getId(), LocalDateTime.of(NOW_PLUS_2_DAYS, FIRST_TIME),
+                        FORM_ITEM_REQUESTS));
+        // when
+        interviewService.cancelAndDeleteAvailableTime(COACH3.getId(), interview.getId(), false);
         Interview updateInterview = interviewService.delete(CREW1.getId(), interview.getId());
 
         // then
@@ -474,7 +492,7 @@ class InterviewServiceTest {
                 new InterviewRequest(COACH3.getId(), LocalDateTime.of(NOW_PLUS_2_DAYS, FIRST_TIME),
                         FORM_ITEM_REQUESTS));
         // when
-        Interview canceledInterview = interviewService.cancelWithDeleteAvailableTime(COACH3.getId(), interview.getId(),
+        Interview canceledInterview = interviewService.cancelAndDeleteAvailableTime(COACH3.getId(), interview.getId(),
                 true);
 
         final boolean expected = availableDateTimeRepository.findByCoachIdAndInterviewDateTime(COACH3.getId(),
@@ -497,7 +515,7 @@ class InterviewServiceTest {
                 new InterviewRequest(COACH2.getId(), LocalDateTime.of(NOW_PLUS_2_DAYS, THIRD_TIME),
                         FORM_ITEM_REQUESTS));
         // when
-        Interview canceledInterview = interviewService.cancelWithDeleteAvailableTime(COACH2.getId(), interview.getId(),
+        Interview canceledInterview = interviewService.cancelAndDeleteAvailableTime(COACH2.getId(), interview.getId(),
                 true);
 
         final boolean expected;
@@ -524,7 +542,7 @@ class InterviewServiceTest {
                         FORM_ITEM_REQUESTS));
         // when  && then
         assertThatThrownBy(
-                () -> interviewService.cancelWithDeleteAvailableTime(COACH2.getId(), interview.getId(), true))
+                () -> interviewService.cancelAndDeleteAvailableTime(COACH2.getId(), interview.getId(), true))
                 .isInstanceOf(InvalidInterviewCoachIdException.class)
                 .hasMessage(INVALID_INTERVIEW_COACH_ID.getMessage());
     }


### PR DESCRIPTION
### Issues
- [x] #259 

### 논의사항
- 코치가 취소할때 면담가능한 시간이 삭제되어 크루가 인터뷰를 삭제할때 면담가능한시간이 find될 수 없기 때문에
- 크루가 면담을 삭제할시 해당 인터뷰의 면담 가능한 시간이 이미 삭제되어있다면 그냥 넘어가도록 수정한다.

close #259 

