### PR TITLE
[BE] refactor: 인터뷰 생성 테스트에 formItem 검증을 containsExactly로 하도록 수정

### DIFF
--- a/backend/src/test/java/com/woowacourse/ternoko/interview/application/InterviewServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/ternoko/interview/application/InterviewServiceTest.java
@@ -101,10 +101,10 @@ class InterviewServiceTest extends DatabaseSupporter {
                         .isEqualTo(LocalDateTime.of(NOW_PLUS_2_DAYS, FIRST_TIME).plusMinutes(INTERVIEW_TIME)),
                 () -> assertThat(interviewResponse.getInterviewQuestions())
                         .extracting("question")
-                        .contains("고정질문1", "고정질문2", "고정질문3"),
+                        .containsExactly("고정질문1", "고정질문2", "고정질문3"),
                 () -> assertThat(interviewResponse.getInterviewQuestions())
                         .extracting("answer")
-                        .contains("답변1", "답변2", "답변3")
+                        .containsExactly("답변1", "답변2", "답변3")
         );
     }
 


### PR DESCRIPTION
### Issues
- [x] #311 

### 논의사항
- 수달이 리팩토링 하기전에는 formItem이 두번 들어가서 containsExactly로 formItem요소 체크하면 터졌었는데, 지금은 이미 해결되었네요!
- 테스트만 수정하고 돌아가는거 확인해서 머지합니당~

close 
#311 


