### PR TITLE
fix: 코치가 취소한 면담을 수정할 시 interviewStatusType을 EDITABLE로 변환

### DIFF
--- a/backend/src/main/java/com/woowacourse/ternoko/interview/domain/Interview.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/interview/domain/Interview.java
@@ -114,6 +114,7 @@ public class Interview {
         this.interviewStartTime = interview.getInterviewStartTime();
         this.interviewEndTime = interview.getInterviewEndTime();
         this.coach = interview.getCoach();
+        this.interviewStatusType = interview.getInterviewStatusType();
         formItems.update(interview.getFormItems());
     }
 


### PR DESCRIPTION
### Issues
- [ ] #326

### 논의사항
interview.update() 메서드에 interviewStatusType 업데이트 로직이 빠져있었습니다.

close #326



