### PR TITLE
[BE] fix: 코치가 면담 취소할 때 되는시간까지 삭제 시 코치가 재예약 안되는 에러해결

### DIFF
--- a/backend/src/main/java/com/woowacourse/ternoko/interview/application/InterviewService.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/interview/application/InterviewService.java
@@ -186,9 +186,8 @@ public class InterviewService {
         changeAvailableTimeStatusIfPresent(originalInterview.getCoach().getId(),
                 originalInterview.getInterviewStartTime(),
                 OPEN);
-        changeAvailableTimeStatusIfPresent(interviewRequest.getCoachId(),
-                interviewRequest.getInterviewDatetime(),
-                USED);
+        final AvailableDateTime afterTime = getAvailableTime(interviewRequest);
+        afterTime.changeStatus(USED);
     }
 
     private Interview getInterviewById(Long interviewId) {

--- a/backend/src/test/java/com/woowacourse/ternoko/interview/application/InterviewServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/ternoko/interview/application/InterviewServiceTest.java
@@ -30,6 +30,7 @@ import static com.woowacourse.ternoko.support.fixture.MemberFixture.CREW4;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -538,29 +539,13 @@ class InterviewServiceTest extends DatabaseSupporter {
                         FORM_ITEM_REQUESTS));
         // when
         interviewService.cancelAndDeleteAvailableTime(COACH3.getId(), interviewId, false);
-        interviewService.update(CREW1.getId(), interviewId, new InterviewRequest(COACH3.getId(),
-                LocalDateTime.of(NOW_PLUS_3_DAYS, SECOND_TIME),
-                FORM_ITEM_UPDATE_REQUESTS));
 
-        final InterviewResponse updatedInterviewResponse = interviewService.findInterviewResponseById(interviewId);
         // then
-        assertAll(
-                () -> assertThat(updatedInterviewResponse.getId()).isNotNull(),
-                () -> assertThat(updatedInterviewResponse.getCoachNickname())
-                        .isEqualTo(COACH3.getNickname()),
-                () -> assertThat(updatedInterviewResponse.getInterviewStartTime())
-                        .isEqualTo(LocalDateTime.of(NOW_PLUS_3_DAYS, SECOND_TIME)),
-                () -> assertThat(updatedInterviewResponse.getInterviewEndTime())
-                        .isEqualTo(LocalDateTime.of(NOW_PLUS_3_DAYS, SECOND_TIME).plusMinutes(INTERVIEW_TIME)),
-                () -> assertThat(updatedInterviewResponse.getInterviewQuestions().stream()
-                        .map(FormItemDto::getQuestion)
-                        .collect(Collectors.toList()))
-                        .contains("수정질문1", "수정질문2", "수정질문3"),
-                () -> assertThat(updatedInterviewResponse.getInterviewQuestions().stream()
-                        .map(FormItemDto::getAnswer)
-                        .collect(Collectors.toList()))
-                        .contains("수정답변1", "수정답변2", "수정답변3"));
-
+        assertDoesNotThrow(
+                () -> interviewService.update(CREW1.getId(), interviewId, new InterviewRequest(COACH3.getId(),
+                        LocalDateTime.of(NOW_PLUS_3_DAYS, SECOND_TIME),
+                        FORM_ITEM_UPDATE_REQUESTS))
+        );
     }
 
     @Test


### PR DESCRIPTION
### Issues
- [ ] #336 

### 논의사항
- 이전 시간이 만약 코치가 삭제했을 경우에는 그냥 넘어가도록 수정했습니다.

close #336 


