### PR TITLE
[BE] fix: 크루가 면담 예약 수정시, 같은 시간에 다른 면담이 있어도 신청이 불가능하게 변경한다.

### DIFF
--- a/backend/src/main/java/com/woowacourse/ternoko/core/application/InterviewService.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/core/application/InterviewService.java
@@ -164,6 +164,7 @@ public class InterviewService {
     public void update(final Long crewId,
                        final Long interviewId,
                        final InterviewRequest interviewRequest) {
+        validateDuplicateStartTimeByCrew(crewId, interviewRequest.getInterviewDatetime());
         final Interview interview = getInterviewById(interviewId);
         final Interview origin = interview.copyOf();
 

--- a/backend/src/test/java/com/woowacourse/ternoko/service/InterviewServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/ternoko/service/InterviewServiceTest.java
@@ -450,6 +450,27 @@ class InterviewServiceTest extends DatabaseSupporter {
     }
 
     @Test
+    @DisplayName("면담 예약 수정 시 같은 시간에 다른 면담이 있으면 수정이 불가능하다. ")
+    void update_WhenDuplicateReservation() {
+        // given
+        coachService.putAvailableDateTimesByCoachId(COACH3.getId(), MONTH_REQUEST);
+        coachService.putAvailableDateTimesByCoachId(COACH4.getId(), MONTH_REQUEST);
+
+        interviewService.create(CREW1.getId(),
+                new InterviewRequest(COACH3.getId(), LocalDateTime.of(NOW_PLUS_2_DAYS, FIRST_TIME),
+                        FORM_ITEM_REQUESTS));
+        final Long interviewId = interviewService.create(CREW1.getId(),
+                new InterviewRequest(COACH4.getId(), LocalDateTime.of(NOW_PLUS_2_DAYS, SECOND_TIME),
+                        FORM_ITEM_REQUESTS));
+        // when & then
+        assertThatThrownBy(() -> interviewService.update(CREW1.getId(), interviewId,
+                new InterviewRequest(COACH4.getId(), LocalDateTime.of(NOW_PLUS_2_DAYS, FIRST_TIME),
+                        FORM_ITEM_UPDATE_REQUESTS)))
+                .isInstanceOf(InvalidInterviewDateException.class)
+                .hasMessage(INVALID_INTERVIEW_DUPLICATE_DATE_TIME.getMessage());
+    }
+
+    @Test
     @DisplayName("크루가 면담 예약을 삭제한다.")
     void delete() {
         // given


### PR DESCRIPTION
### Issues
- [ ] #342 

### 논의사항
- validateDuplicateStartTimeByCrew 메서드 update에도 추가하였습니다.

close #342 


