### PR TITLE
[BE] formItem, member test 보강

### DIFF
--- a/backend/src/main/java/com/woowacourse/ternoko/auth/application/AuthService.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/auth/application/AuthService.java
@@ -64,6 +64,7 @@ public class AuthService {
         if (member.isEmpty()) {
             return signUp(userInfoResponse);
         }
+
         boolean hasNickname = member.get().getNickname() != null;
 
         if (coachRepository.findById(member.get().getId()).isPresent()) {

--- a/backend/src/main/java/com/woowacourse/ternoko/core/domain/availabledatetime/AvailableDateTimeStatus.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/core/domain/availabledatetime/AvailableDateTimeStatus.java
@@ -1,6 +1,7 @@
 package com.woowacourse.ternoko.core.domain.availabledatetime;
 
 public enum AvailableDateTimeStatus {
+
     OPEN,
     USED;
 

--- a/backend/src/main/java/com/woowacourse/ternoko/core/domain/interview/Interview.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/core/domain/interview/Interview.java
@@ -33,16 +33,14 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.OneToOne;
 import lombok.AllArgsConstructor;
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @Entity
-@EqualsAndHashCode
 @NoArgsConstructor
 @AllArgsConstructor
-public class  Interview {
+public class Interview {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/backend/src/main/java/com/woowacourse/ternoko/core/domain/interview/formitem/Answer.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/core/domain/interview/formitem/Answer.java
@@ -5,12 +5,14 @@ import static com.woowacourse.ternoko.common.exception.ExceptionType.OVER_LENGTH
 import com.woowacourse.ternoko.common.exception.InvalidLengthException;
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @Embeddable
 @NoArgsConstructor
+@EqualsAndHashCode
 public class Answer {
 
     private static final int ANSWER_MAX_LENGTH = 1000;

--- a/backend/src/main/java/com/woowacourse/ternoko/core/domain/interview/formitem/FormItem.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/core/domain/interview/formitem/FormItem.java
@@ -8,12 +8,14 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @Entity
 @NoArgsConstructor
+@EqualsAndHashCode
 public class FormItem {
 
     @Id

--- a/backend/src/main/java/com/woowacourse/ternoko/core/domain/interview/formitem/FormItems.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/core/domain/interview/formitem/FormItems.java
@@ -3,6 +3,7 @@ package com.woowacourse.ternoko.core.domain.interview.formitem;
 import com.woowacourse.ternoko.core.domain.interview.Interview;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import javax.persistence.CascadeType;
 import javax.persistence.Embeddable;
 import javax.persistence.OneToMany;
@@ -16,6 +17,11 @@ public class FormItems {
 
     @OneToMany(mappedBy = "interview", cascade = {CascadeType.PERSIST, CascadeType.REMOVE})
     private List<FormItem> formItems;
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(formItems);
+    }
 
     public FormItems(final List<FormItem> formItems, final Interview interview) {
         this.formItems = new ArrayList<>(formItems);
@@ -32,5 +38,17 @@ public class FormItems {
         for (FormItem formItem : formItems) {
             formItem.addInterview(interview);
         }
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final FormItems formItems1 = (FormItems) o;
+        return Objects.equals(formItems, formItems1.formItems);
     }
 }

--- a/backend/src/main/java/com/woowacourse/ternoko/core/domain/interview/formitem/FormItems.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/core/domain/interview/formitem/FormItems.java
@@ -3,25 +3,21 @@ package com.woowacourse.ternoko.core.domain.interview.formitem;
 import com.woowacourse.ternoko.core.domain.interview.Interview;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 import javax.persistence.CascadeType;
 import javax.persistence.Embeddable;
 import javax.persistence.OneToMany;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @Embeddable
 @NoArgsConstructor
+@EqualsAndHashCode
 public class FormItems {
 
     @OneToMany(mappedBy = "interview", cascade = {CascadeType.PERSIST, CascadeType.REMOVE})
     private List<FormItem> formItems;
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(formItems);
-    }
 
     public FormItems(final List<FormItem> formItems, final Interview interview) {
         this.formItems = new ArrayList<>(formItems);
@@ -38,17 +34,5 @@ public class FormItems {
         for (FormItem formItem : formItems) {
             formItem.addInterview(interview);
         }
-    }
-
-    @Override
-    public boolean equals(final Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        final FormItems formItems1 = (FormItems) o;
-        return Objects.equals(formItems, formItems1.formItems);
     }
 }

--- a/backend/src/main/java/com/woowacourse/ternoko/core/domain/interview/formitem/Question.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/core/domain/interview/formitem/Question.java
@@ -5,12 +5,14 @@ import static com.woowacourse.ternoko.common.exception.ExceptionType.OVER_LENGTH
 import com.woowacourse.ternoko.common.exception.InvalidLengthException;
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @Embeddable
 @NoArgsConstructor
+@EqualsAndHashCode
 public class Question {
 
     private static final int QUESTION_MAX_LENGTH = 255;

--- a/backend/src/test/java/com/woowacourse/ternoko/core/domain/interview/formitem/FormItemTest.java
+++ b/backend/src/test/java/com/woowacourse/ternoko/core/domain/interview/formitem/FormItemTest.java
@@ -1,0 +1,24 @@
+package com.woowacourse.ternoko.core.domain.interview.formitem;
+
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class FormItemTest {
+
+    @DisplayName("면담 사전 질문 업데이트 정상 수행 ")
+    @Test
+    void update_formItem() {
+        // given
+        final FormItem formItem = FormItem.of("테스트 질문", "테스트 답변");
+        final FormItem updateFormItem = FormItem.of("업데이트 테스트 질문", "업데이트 테스트 답변");
+
+        // when
+        formItem.update(updateFormItem);
+
+        // then
+        assertThat(formItem).isEqualTo(updateFormItem);
+    }
+}

--- a/backend/src/test/java/com/woowacourse/ternoko/core/domain/interview/formitem/FormItemsTest.java
+++ b/backend/src/test/java/com/woowacourse/ternoko/core/domain/interview/formitem/FormItemsTest.java
@@ -1,0 +1,28 @@
+package com.woowacourse.ternoko.core.domain.interview.formitem;
+
+import static com.woowacourse.ternoko.support.fixture.InterviewFixture.FORM_ITEMS1;
+import static com.woowacourse.ternoko.support.fixture.InterviewFixture.FORM_ITEMS2;
+import static com.woowacourse.ternoko.support.fixture.InterviewFixture.INTERVIEW;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import com.woowacourse.ternoko.core.domain.interview.Interview;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class FormItemsTest {
+
+    @DisplayName("면담 사전 질문 List 업데이트 정상 수행 확인")
+    @Test
+    void update_formItems() {
+        // given
+        final Interview interview = INTERVIEW.copyOf();
+        final FormItems formItems = new FormItems(FORM_ITEMS1, interview);
+        final List<FormItem> updateFormItemList = FORM_ITEMS2;
+
+        formItems.update(updateFormItemList);
+
+        // then
+        assertThat(formItems.getFormItems().equals(updateFormItemList));
+    }
+}

--- a/backend/src/test/java/com/woowacourse/ternoko/core/domain/member/coach/CoachRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/ternoko/core/domain/member/coach/CoachRepositoryTest.java
@@ -1,0 +1,69 @@
+package com.woowacourse.ternoko.core.domain.member.coach;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.woowacourse.ternoko.core.domain.member.MemberRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.dao.DataIntegrityViolationException;
+
+@DataJpaTest
+class CoachRepositoryTest {
+
+    @Autowired
+    private CoachRepository coachRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+
+    @DisplayName("코치의 닉네임과 이미지, 소개를  업데이트 한다.")
+    @Test
+    void updateNickNameAndImageUrlAndIntroduce() {
+        // given
+        final Coach 코치 = memberRepository.save(
+                new Coach(null, "이름", "변경전", "변경전@test.com", "U9234567891", "imageUrl", "안녕하세요."));
+
+        String nickName = "변경후";
+        String imgUrl = "update img url";
+        String introduce = "update introduce content";
+        // when
+        coachRepository.updateNickNameAndImageUrlAndIntroduce(코치.getId(), nickName, imgUrl, introduce);
+        final Coach 변경_후_코치 = coachRepository.findById(코치.getId()).get();
+
+        // then
+        assertAll(
+                () -> assertEquals(변경_후_코치.getNickname(), nickName),
+                () -> assertEquals(변경_후_코치.getImageUrl(), imgUrl),
+                () -> assertEquals(변경_후_코치.getIntroduce(), introduce)
+        );
+
+        coachRepository.delete(변경_후_코치);
+    }
+
+
+    @DisplayName("업데이트 될 코치의 닉네임이 고유하지 않으면 에러가 발생한다.")
+    @Test
+    void updateNickNameAndImageUrlAndIntroduceNotUniqueNickname() {
+        // given
+        final Coach 코치 = memberRepository.save(
+                new Coach(null, "이름", "변경전", "변경전@test.com", "U9234567891", "imageUrl", "안녕하세요."));
+
+        String existNickname = "수달";
+        String imgUrl = "update img url";
+        String introduce = "update introduce content";
+        // when
+
+        // then
+        assertThatThrownBy(
+                () -> coachRepository.updateNickNameAndImageUrlAndIntroduce(코치.getId(), existNickname, imgUrl,
+                        introduce))
+                .isInstanceOf(DataIntegrityViolationException.class);
+
+        coachRepository.delete(코치);
+    }
+}

--- a/backend/src/test/java/com/woowacourse/ternoko/core/domain/member/crew/CrewRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/ternoko/core/domain/member/crew/CrewRepositoryTest.java
@@ -1,0 +1,44 @@
+package com.woowacourse.ternoko.core.domain.member.crew;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.woowacourse.ternoko.core.domain.member.MemberRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+class CrewRepositoryTest {
+
+    @Autowired
+    private CrewRepository crewRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+
+    @DisplayName("코치의 닉네임과 이미지, 소개를  업데이트 한다.")
+    @Test
+    void updateNickNameAndImageUrlAndIntroduce() {
+        // given
+        final Crew 크루 = memberRepository.save(
+                new Crew(null, "이름", "변경전", "변경전@test.com", "U9234567891", "imageUrl"));
+
+        String nickName = "변경후";
+        String imgUrl = "update img url";
+        // when
+
+        crewRepository.updateNickNameAndImageUrl(크루.getId(), nickName, imgUrl);
+        final Crew 변경_후_크루 = crewRepository.findById(크루.getId()).get();
+
+        // then
+        assertAll(
+                () -> assertEquals(변경_후_크루.getNickname(), nickName),
+                () -> assertEquals(변경_후_크루.getImageUrl(), imgUrl)
+        );
+
+        crewRepository.delete(변경_후_크루);
+    }
+}

--- a/backend/src/test/java/com/woowacourse/ternoko/domain/comment/CommentTest.java
+++ b/backend/src/test/java/com/woowacourse/ternoko/domain/comment/CommentTest.java
@@ -32,7 +32,7 @@ public class CommentTest {
 
     @DisplayName("면담의 상태가 코멘트를 멘트를 생성하면 예외를 반환한다.")
     @ParameterizedTest
-    @EnumSource(value = InterviewStatusType.class, names = {"EDITABLE", "COMPLETE", "CANCELED"})
+    @EnumSource(value = InterviewStatusType.class, names = {"EDITABLE", "COMPLETED", "CANCELED"})
     void create_comment(InterviewStatusType type) {
         final Interview 코멘트_불가_상태_면담 = new Interview(null, LocalDateTime.now().minusDays(1),
                 LocalDateTime.now().minusDays(1).plusMinutes(30), COACH1, CREW1, FORM_ITEMS1, type);

--- a/backend/src/test/java/com/woowacourse/ternoko/domain/comment/CommentTest.java
+++ b/backend/src/test/java/com/woowacourse/ternoko/domain/comment/CommentTest.java
@@ -1,5 +1,66 @@
 package com.woowacourse.ternoko.domain.comment;
 
-//TODO: CommentServiceTest 에서 도메인 관련 검증로직 옮겨오기
+import static com.woowacourse.ternoko.core.domain.interview.InterviewStatusType.FIXED;
+import static com.woowacourse.ternoko.support.fixture.InterviewFixture.FORM_ITEMS1;
+import static com.woowacourse.ternoko.support.fixture.MemberFixture.COACH1;
+import static com.woowacourse.ternoko.support.fixture.MemberFixture.COACH2;
+import static com.woowacourse.ternoko.support.fixture.MemberFixture.CREW1;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.woowacourse.ternoko.common.exception.exception.InvalidCommentMemberIdException;
+import com.woowacourse.ternoko.common.exception.exception.InvalidStatusCreateCommentException;
+import com.woowacourse.ternoko.core.domain.comment.Comment;
+import com.woowacourse.ternoko.core.domain.interview.Interview;
+import com.woowacourse.ternoko.core.domain.interview.InterviewStatusType;
+import com.woowacourse.ternoko.core.domain.member.MemberType;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
 public class CommentTest {
+
+    @DisplayName("면담 젼에 코멘트를 생성하면 예외를 반환한다.a")
+    @Test
+    void create_comment_before_now() {
+        final Interview 진행_예정_인터뷰 = Interview.of(LocalDateTime.now().plusDays(1), COACH1, CREW1, FORM_ITEMS1);
+
+        assertThatThrownBy(() -> Comment.create(COACH1.getId(), 진행_예정_인터뷰, "테스트 코멘트", MemberType.COACH))
+                .isInstanceOf(InvalidStatusCreateCommentException.class);
+    }
+
+    @DisplayName("면담의 상태가 코멘트를 멘트를 생성하면 예외를 반환한다.")
+    @ParameterizedTest
+    @EnumSource(value = InterviewStatusType.class, names = {"EDITABLE", "COMPLETE", "CANCELED"})
+    void create_comment(InterviewStatusType type) {
+        final Interview 코멘트_불가_상태_면담 = new Interview(null, LocalDateTime.now().minusDays(1),
+                LocalDateTime.now().minusDays(1).plusMinutes(30), COACH1, CREW1, FORM_ITEMS1, type);
+        assertThatThrownBy(() -> Comment.create(COACH1.getId(), 코멘트_불가_상태_면담, "테스트 코멘트", MemberType.COACH))
+                .isInstanceOf(InvalidStatusCreateCommentException.class);
+    }
+
+    @DisplayName("코멘트 작성자가 아니면, 코멘트를 업데이트 할 수 없다.")
+    @Test
+    void update_comment_false() {
+        // give
+        final Interview 진행_완료_인터뷰 = new Interview(null, LocalDateTime.now().minusDays(5),
+                LocalDateTime.now().minusDays(5).plusMinutes(30), COACH1, CREW1, FORM_ITEMS1, FIXED);
+        final Comment 코멘트 = Comment.create(COACH1.getId(), 진행_완료_인터뷰, "테스트 코멘트", MemberType.COACH);
+
+        assertThatThrownBy(() -> 코멘트.update(COACH2.getId(), 진행_완료_인터뷰.getId(), "업데이트 코멘트"))
+                .isInstanceOf(InvalidCommentMemberIdException.class);
+    }
+
+    @DisplayName("인터뷰 작성자가 아니면 코멘트를 업데이트 할 수 없다.")
+    @Test
+    void update_comment_interview_Id_false() {
+        // give
+        final Interview 진행_완료_인터뷰 = new Interview(1L, LocalDateTime.now().minusDays(5),
+                LocalDateTime.now().minusDays(5).plusMinutes(30), COACH1, CREW1, FORM_ITEMS1, FIXED);
+        final Comment 코멘트 = Comment.create(COACH1.getId(), 진행_완료_인터뷰, "테스트 코멘트", MemberType.COACH);
+
+        assertThatThrownBy(() -> 코멘트.update(COACH2.getId(), 2L, "업데이트 코멘트"))
+                .isInstanceOf(InvalidCommentMemberIdException.class);
+    }
 }

--- a/backend/src/test/java/com/woowacourse/ternoko/support/fixture/InterviewFixture.java
+++ b/backend/src/test/java/com/woowacourse/ternoko/support/fixture/InterviewFixture.java
@@ -44,14 +44,6 @@ public class InterviewFixture {
             createFormItem(5L),
             createFormItem(6L));
 
-//    public static final List<FormItem> FORM_ITEMS1 = List.of(createFormItem(1),
-//            createFormItem(2),
-//            createFormItem(3));
-//
-//    public static final List<FormItem> FORM_ITEMS2 = List.of(createFormItem(4),
-//            createFormItem(5),
-//            createFormItem(6));
-
     private static FormItem createFormItem(Long count) {
         return new FormItem(null, Question.from("고정질문" + count), Answer.from("고정답변" + count));
     }

--- a/backend/src/test/java/com/woowacourse/ternoko/support/fixture/InterviewFixture.java
+++ b/backend/src/test/java/com/woowacourse/ternoko/support/fixture/InterviewFixture.java
@@ -19,9 +19,9 @@ public class InterviewFixture {
 
     public static final Interview INTERVIEW = new Interview(1L, LocalDateTime.now().plusDays(10),
             LocalDateTime.now().minusDays(2),
-            COACH1, CREW1, List.of(createFormItem(1),
-            createFormItem(2),
-            createFormItem(3)), InterviewStatusType.FIXED);
+            COACH1, CREW1, List.of(createFormItem(1L),
+            createFormItem(2L),
+            createFormItem(3L)), InterviewStatusType.FIXED);
 
     private static final LocalDateTime NOW = LocalDateTime.now().withNano(0).plusDays(2);
     public static final LocalDateTime AFTER_TWO_DAYS = LocalDateTime.of(NOW.getYear(), NOW.getMonthValue(),
@@ -36,15 +36,23 @@ public class InterviewFixture {
             new FormItemRequest("수정질문3", "수정답변3"));
 
 
-    public static final List<FormItem> FORM_ITEMS1 = List.of(createFormItem(1),
-            createFormItem(2),
-            createFormItem(3));
+    public static final List<FormItem> FORM_ITEMS1 = List.of(createFormItem(1L),
+            createFormItem(2L),
+            createFormItem(3L));
 
-    public static final List<FormItem> FORM_ITEMS2 = List.of(createFormItem(4),
-            createFormItem(5),
-            createFormItem(6));
+    public static final List<FormItem> FORM_ITEMS2 = List.of(createFormItem(4L),
+            createFormItem(5L),
+            createFormItem(6L));
 
-    private static FormItem createFormItem(int count) {
+//    public static final List<FormItem> FORM_ITEMS1 = List.of(createFormItem(1),
+//            createFormItem(2),
+//            createFormItem(3));
+//
+//    public static final List<FormItem> FORM_ITEMS2 = List.of(createFormItem(4),
+//            createFormItem(5),
+//            createFormItem(6));
+
+    private static FormItem createFormItem(Long count) {
         return new FormItem(null, Question.from("고정질문" + count), Answer.from("고정답변" + count));
     }
 


### PR DESCRIPTION
### Issues
- [x] #371 

### 논의사항
테스트 코드를 보강하면서 formItem 객체 자체에 대해서 비교 검증이 필요했어요. 
그래서 찾아보던 중 JPA 에서 Entity 로 사용 하는 객체에 외에 Embedded 인 answer 과 question 에 대해서 EqualsAndHashCode 
가 재정의되어 있지 않아서 문제가 발생할 가능성이 있음을 발견했습니다.

따라서 앞으로 Entity 내에서 Embedded 로 사용되는 객체에 대해서 EqualsAndHashCode 를 재정의 해줘야겠다고 느꼈습니다.

근거는 아래와 같습니다. 

JPA는 영속성 컨텍스트의 키로 엔티티의 식별자를 사용한다.
기본적인 wrapper 타입의 경우 equals가 잘 구현되어 있기 때문에 상관없으나
@EmbeddedId의 경우 equals, hashCode를 구현해주지 않으면 두 엔티티가 같다는 것을 보장해줄 수 없다.

equals, hashCode를 구현하지 않았다면 똑같은 식별자를 가졌음에도 불구하고 영속성 컨텍스트에 두번 들어가게 된다.
그러므로 @EmbeddedId에 대해서는 꼭 equals, hashCode를 구현해줘야 한다.

### 참고 자료
https://www.jpa-buddy.com/blog/lombok-and-jpa-what-may-go-wrong/
https://joont92.github.io/jpa/jpa-entity-equals-hashcode/

close #371 


