### PR TITLE
[BE] fix: restDocs 404 error를 해결한다. 

### DIFF
--- a/backend/src/docs/asciidoc/api.adoc
+++ b/backend/src/docs/asciidoc/api.adoc
@@ -116,7 +116,8 @@ operation::coach-controller-test/update-coach[snippets='http-request,http-respon
 
 GET /api/crews/me
 
-operation::crew-controller-test/find-coach[snippets='http-request,http-response']
+operation::crew-controller-test/find-crew[snippets='http-request,http-response']
+
 ==== Error Response
 
 |===
@@ -140,7 +141,7 @@ operation::crew-controller-test/find-coach[snippets='http-request,http-response'
 
 PATCH /api/crews/me
 
-operation::crew-controller-test/update-coach[snippets='http-request,http-response']
+operation::crew-controller-test/update-crew[snippets='http-request,http-response']
 ==== Error Response
 
 |===

--- a/backend/src/main/java/com/woowacourse/ternoko/config/WebConfig.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/config/WebConfig.java
@@ -5,6 +5,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpHeaders;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
@@ -29,5 +30,12 @@ public class WebConfig implements WebMvcConfigurer {
     public void addInterceptors(final InterceptorRegistry registry) {
         registry.addInterceptor(logInterceptor)
                 .addPathPatterns("/**");
+    }
+
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        registry.addResourceHandler("/docs/**")
+                .addResourceLocations("classpath:/BOOT-INF/classes/static/docs/")
+                .addResourceLocations("classpath:/static/docs/");
     }
 }


### PR DESCRIPTION
### Issues
- [ ] #321 

### 논의사항
- restDocs자원을 가져올 수 있게 WebConfig addResourceHandlers 추가하였습니다.
- api.adoc 문서에 crew 내 정보 조회, 수정 http request, response 경로 수정하였습니다.
- build 실행 후 jar파일을 실행하고 https://localhost:8080/docs/api.html 로 접근이 가능한지 확인하시면 감사하겠습니다. 

트러블 슈팅 참고 블로그: [WebConfig활용](https://oingdaddy.tistory.com/410)

close #321 


