### PR TITLE
[BE] fix: 코치의 스케줄 조회시 인터뷰 상태 필드명을 Status로 반환하도록 수정

### DIFF
--- a/backend/src/main/java/com/woowacourse/ternoko/core/dto/response/CalendarResponse.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/core/dto/response/CalendarResponse.java
@@ -1,6 +1,7 @@
 package com.woowacourse.ternoko.core.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.woowacourse.ternoko.core.domain.interview.Interview;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
@@ -20,6 +21,7 @@ public class CalendarResponse {
     private LocalDateTime interviewStartTime;
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
     private LocalDateTime interviewEndTime;
+    @JsonProperty(value = "status")
     private String interviewStatus;
 
     public static CalendarResponse from(final Interview interview) {


### PR DESCRIPTION
### Issues
- [x] #384 

### 논의사항

CalendarResponse의 interviewStatus 필드를 json으로 변환할때 필드명을 status 를 사용하도록 수정했습니다.
원래는 interviewStatus 였는데 그냥 Status로 필드명을 바꿔버리면 나중에 interviewStatus인줄 모를 것 같아서요!

close #384 


