### PR TITLE
[BE] refactor: 중복된 멤버 이름으로 닉네임 수정 시 검증 로직 추가

### DIFF
--- a/backend/src/main/java/com/woowacourse/ternoko/common/exception/ExceptionType.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/common/exception/ExceptionType.java
@@ -16,6 +16,7 @@ public enum ExceptionType {
     // Coach 관련 Exception
     COACH_NOT_FOUND(2001, "번째 코치를 찾을 수 없습니다."),
     INVALID_INTERVIEW_COACH_ID(2002, "다른 코치의 예약에 접근할 수 없습니다."),
+    DUPLICATED_MEMBER_NICKNAME(2003, "이미 존재하는 회원 닉네임입니다."),
 
     // Crew 관련 Exception,
     CREW_NOT_FOUND(3001, "번째 크루를 찾을 수 없습니다."),

--- a/backend/src/main/java/com/woowacourse/ternoko/common/exception/InvalidMemberNicknameException.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/common/exception/InvalidMemberNicknameException.java
@@ -1,0 +1,10 @@
+package com.woowacourse.ternoko.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class InvalidMemberNicknameException extends CommonException {
+
+    public InvalidMemberNicknameException(final ExceptionType exceptionType) {
+        super(HttpStatus.BAD_REQUEST, exceptionType.getStatusCode(), exceptionType.getMessage());
+    }
+}

--- a/backend/src/main/java/com/woowacourse/ternoko/core/application/CoachService.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/core/application/CoachService.java
@@ -103,12 +103,11 @@ public class CoachService {
     }
 
     public void partUpdateCoach(final Long coachId, final CoachUpdateRequest coachUpdateRequest) {
-        final Coach coach = getCoachById(coachId);
         final String requestNickname = coachUpdateRequest.getNickname();
 
-        if (!coach.isSameNickname(requestNickname) 
-                && memberRepository.existsByNickname(requestNickname)) {
+        if (memberRepository.existsByIdAndNicknameExceptMe(coachId, requestNickname)) {
             throw new InvalidMemberNicknameException(DUPLICATED_MEMBER_NICKNAME);
+
         }
         coachRepository.updateNickNameAndImageUrlAndIntroduce(coachId,
                 coachUpdateRequest.getNickname(),

--- a/backend/src/main/java/com/woowacourse/ternoko/core/application/CoachService.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/core/application/CoachService.java
@@ -102,7 +102,7 @@ public class CoachService {
         return availableDateTimeRepository.findOpenAvailableDateTimesByCoachId(coachId, year, month);
     }
 
-    public void partUpdateCoach(final Long coachId, final CoachUpdateRequest coachUpdateRequest) {
+    public void updateCoach(final Long coachId, final CoachUpdateRequest coachUpdateRequest) {
         final String requestNickname = coachUpdateRequest.getNickname();
 
         if (memberRepository.existsByIdAndNicknameExceptMe(coachId, requestNickname)) {

--- a/backend/src/main/java/com/woowacourse/ternoko/core/application/CrewService.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/core/application/CrewService.java
@@ -1,7 +1,11 @@
 package com.woowacourse.ternoko.core.application;
 
+import static com.woowacourse.ternoko.common.exception.ExceptionType.DUPLICATED_MEMBER_NICKNAME;
+
 import com.woowacourse.ternoko.common.exception.CrewNotFoundException;
 import com.woowacourse.ternoko.common.exception.ExceptionType;
+import com.woowacourse.ternoko.common.exception.InvalidMemberNicknameException;
+import com.woowacourse.ternoko.core.domain.member.MemberRepository;
 import com.woowacourse.ternoko.core.domain.member.crew.Crew;
 import com.woowacourse.ternoko.core.domain.member.crew.CrewRepository;
 import com.woowacourse.ternoko.core.dto.request.CrewUpdateRequest;
@@ -18,8 +22,16 @@ import org.springframework.transaction.annotation.Transactional;
 public class CrewService {
 
     private final CrewRepository crewRepository;
+    private final MemberRepository memberRepository;
 
     public void partUpdateCrew(final Long crewId, final CrewUpdateRequest request) {
+        final Crew crew = getCrewById(crewId);
+        final String requestNickname = request.getNickname();
+
+        if (!crew.isSameNickname(requestNickname)
+                && memberRepository.existsByNickname(request.getNickname())) {
+            throw new InvalidMemberNicknameException(DUPLICATED_MEMBER_NICKNAME);
+        }
         crewRepository.updateNickNameAndImageUrl(crewId, request.getNickname(), request.getImageUrl());
     }
 

--- a/backend/src/main/java/com/woowacourse/ternoko/core/application/CrewService.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/core/application/CrewService.java
@@ -24,7 +24,7 @@ public class CrewService {
     private final CrewRepository crewRepository;
     private final MemberRepository memberRepository;
 
-    public void partUpdateCrew(final Long crewId, final CrewUpdateRequest request) {
+    public void updateCrew(final Long crewId, final CrewUpdateRequest request) {
         final String requestNickname = request.getNickname();
 
         if (memberRepository.existsByIdAndNicknameExceptMe(crewId, requestNickname)) {

--- a/backend/src/main/java/com/woowacourse/ternoko/core/application/CrewService.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/core/application/CrewService.java
@@ -25,11 +25,9 @@ public class CrewService {
     private final MemberRepository memberRepository;
 
     public void partUpdateCrew(final Long crewId, final CrewUpdateRequest request) {
-        final Crew crew = getCrewById(crewId);
         final String requestNickname = request.getNickname();
 
-        if (!crew.isSameNickname(requestNickname)
-                && memberRepository.existsByNickname(request.getNickname())) {
+        if (memberRepository.existsByIdAndNicknameExceptMe(crewId, requestNickname)) {
             throw new InvalidMemberNicknameException(DUPLICATED_MEMBER_NICKNAME);
         }
         crewRepository.updateNickNameAndImageUrl(crewId, request.getNickname(), request.getImageUrl());

--- a/backend/src/main/java/com/woowacourse/ternoko/core/domain/member/Member.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/core/domain/member/Member.java
@@ -47,4 +47,8 @@ public class Member {
     public boolean isSameId(Long id) {
         return this.id.equals(id);
     }
+
+    public boolean isSameNickname(String nickname) {
+        return nickname.equals(this.nickname);
+    }
 }

--- a/backend/src/main/java/com/woowacourse/ternoko/core/domain/member/MemberRepository.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/core/domain/member/MemberRepository.java
@@ -2,6 +2,8 @@ package com.woowacourse.ternoko.core.domain.member;
 
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
@@ -9,5 +11,7 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findByNickname(String nickname);
 
-    boolean existsByNickname(String nickname);
+    @Query("SELECT COUNT (m.id) > 0 FROM Member m WHERE m.nickname = :nickname AND m.id <> :memberId")
+    boolean existsByIdAndNicknameExceptMe(@Param("memberId") final Long memberId,
+                                          @Param("nickname") final String nickname);
 }

--- a/backend/src/main/java/com/woowacourse/ternoko/core/domain/member/MemberRepository.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/core/domain/member/MemberRepository.java
@@ -8,4 +8,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByEmail(String email);
 
     Optional<Member> findByNickname(String nickname);
+
+    boolean existsByNickname(String nickname);
 }

--- a/backend/src/main/java/com/woowacourse/ternoko/core/presentation/CoachController.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/core/presentation/CoachController.java
@@ -54,7 +54,7 @@ public class CoachController {
     @PatchMapping("/coaches/me")
     public ResponseEntity<Void> updateCoach(@AuthenticationPrincipal final Long coachId,
                                             @RequestBody final CoachUpdateRequest coachUpdateRequest) {
-        coachService.partUpdateCrew(coachId, coachUpdateRequest);
+        coachService.partUpdateCoach(coachId, coachUpdateRequest);
         return ResponseEntity.ok().build();
     }
 }

--- a/backend/src/main/java/com/woowacourse/ternoko/core/presentation/CoachController.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/core/presentation/CoachController.java
@@ -54,7 +54,7 @@ public class CoachController {
     @PatchMapping("/coaches/me")
     public ResponseEntity<Void> updateCoach(@AuthenticationPrincipal final Long coachId,
                                             @RequestBody final CoachUpdateRequest coachUpdateRequest) {
-        coachService.partUpdateCoach(coachId, coachUpdateRequest);
+        coachService.updateCoach(coachId, coachUpdateRequest);
         return ResponseEntity.ok().build();
     }
 }

--- a/backend/src/main/java/com/woowacourse/ternoko/core/presentation/CrewController.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/core/presentation/CrewController.java
@@ -32,7 +32,7 @@ public class CrewController {
     @PatchMapping("/me")
     public ResponseEntity<Void> updateCrew(@AuthenticationPrincipal final Long crewId,
                                            @RequestBody final CrewUpdateRequest crewUpdateRequest) {
-        crewService.partUpdateCrew(crewId, crewUpdateRequest);
+        crewService.updateCrew(crewId, crewUpdateRequest);
         return ResponseEntity.ok().build();
     }
 }

--- a/backend/src/test/java/com/woowacourse/ternoko/api/CoachControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/ternoko/api/CoachControllerTest.java
@@ -91,7 +91,7 @@ public class CoachControllerTest extends RestDocsTestSupporter {
     @Test
     @DisplayName("코치 - 내 정보를 수정한다.")
     void updateCoach() throws Exception {
-        doNothing().when(coachService).partUpdateCoach(any(), any());
+        doNothing().when(coachService).updateCoach(any(), any());
         // given, when, then
         mockMvc.perform(MockMvcRequestBuilders
                         .patch("/api/coaches/me")

--- a/backend/src/test/java/com/woowacourse/ternoko/api/CoachControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/ternoko/api/CoachControllerTest.java
@@ -91,7 +91,7 @@ public class CoachControllerTest extends RestDocsTestSupporter {
     @Test
     @DisplayName("코치 - 내 정보를 수정한다.")
     void updateCoach() throws Exception {
-        doNothing().when(coachService).partUpdateCrew(any(), any());
+        doNothing().when(coachService).partUpdateCoach(any(), any());
         // given, when, then
         mockMvc.perform(MockMvcRequestBuilders
                         .patch("/api/coaches/me")

--- a/backend/src/test/java/com/woowacourse/ternoko/api/CrewControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/ternoko/api/CrewControllerTest.java
@@ -34,7 +34,7 @@ public class CrewControllerTest extends RestDocsTestSupporter {
     @Test
     @DisplayName("크루 - 내 정보를 수정한다.")
     void updateCrew() throws Exception {
-        doNothing().when(crewService).partUpdateCrew(any(), any());
+        doNothing().when(crewService).updateCrew(any(), any());
         // given, when, then
         mockMvc.perform(MockMvcRequestBuilders
                         .patch("/api/crews/me")

--- a/backend/src/test/java/com/woowacourse/ternoko/service/CoachServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/ternoko/service/CoachServiceTest.java
@@ -144,7 +144,7 @@ public class CoachServiceTest extends DatabaseSupporter {
                 new Coach("공지철", "공유", " share@woowahan.com", userId, imageUrl, "null"));
 
         //when
-        coachService.partUpdateCoach(savedCoach.getId(), new CoachUpdateRequest(nickname, imageUrl, introduce));
+        coachService.updateCoach(savedCoach.getId(), new CoachUpdateRequest(nickname, imageUrl, introduce));
         final CoachResponse foundCoach = coachService.findCoach(savedCoach.getId());
 
         //then
@@ -169,7 +169,7 @@ public class CoachServiceTest extends DatabaseSupporter {
                 new Coach("공지철", "공유", " share@woowahan.com", userId, imageUrl, "null"));
 
         //when
-        coachService.partUpdateCoach(savedCoach.getId(), new CoachUpdateRequest(nickname, imageUrl, introduce));
+        coachService.updateCoach(savedCoach.getId(), new CoachUpdateRequest(nickname, imageUrl, introduce));
         final CoachResponse foundCoach = coachService.findCoach(savedCoach.getId());
 
         //then
@@ -194,7 +194,7 @@ public class CoachServiceTest extends DatabaseSupporter {
                 new Coach("공지철", "도깨비", " share@woowahan.com", userId, imageUrl, "null"));
 
         //when, then
-        assertThatThrownBy(() -> coachService.partUpdateCoach(savedCoach.getId(),
+        assertThatThrownBy(() -> coachService.updateCoach(savedCoach.getId(),
                 new CoachUpdateRequest(nickname, imageUrl, introduce)))
                 .isInstanceOf(InvalidMemberNicknameException.class);
 

--- a/backend/src/test/java/com/woowacourse/ternoko/service/CoachServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/ternoko/service/CoachServiceTest.java
@@ -4,6 +4,7 @@ import static com.woowacourse.ternoko.support.fixture.CoachAvailableTimeFixture.
 import static com.woowacourse.ternoko.support.fixture.CoachAvailableTimeFixture.MONTH_REQUEST;
 import static com.woowacourse.ternoko.support.fixture.CoachAvailableTimeFixture.NOW;
 import static com.woowacourse.ternoko.support.fixture.CoachAvailableTimeFixture.NOW_PLUS_1_MONTH;
+import static com.woowacourse.ternoko.support.fixture.MemberFixture.COACH1;
 import static com.woowacourse.ternoko.support.fixture.MemberFixture.COACH3;
 import static com.woowacourse.ternoko.support.fixture.MemberFixture.TIME2;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -11,6 +12,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.woowacourse.ternoko.common.exception.CoachNotFoundException;
+import com.woowacourse.ternoko.common.exception.InvalidMemberNicknameException;
 import com.woowacourse.ternoko.core.application.CoachService;
 import com.woowacourse.ternoko.core.domain.availabledatetime.AvailableDateTime;
 import com.woowacourse.ternoko.core.domain.availabledatetime.AvailableDateTimeRepository;
@@ -142,7 +144,7 @@ public class CoachServiceTest extends DatabaseSupporter {
                 new Coach("공지철", "공유", " share@woowahan.com", userId, imageUrl, "null"));
 
         //when
-        coachService.partUpdateCrew(savedCoach.getId(), new CoachUpdateRequest(nickname, imageUrl, introduce));
+        coachService.partUpdateCoach(savedCoach.getId(), new CoachUpdateRequest(nickname, imageUrl, introduce));
         final CoachResponse foundCoach = coachService.findCoach(savedCoach.getId());
 
         //then
@@ -150,6 +152,51 @@ public class CoachServiceTest extends DatabaseSupporter {
                 () -> assertThat(foundCoach.getNickname()).isEqualTo(nickname),
                 () -> assertThat(foundCoach.getIntroduce()).isEqualTo(introduce)
         );
+
+        coachRepository.delete(savedCoach);
+    }
+
+    @Test
+    @DisplayName("slack 회원가입 후 닉네임 변경 시 동일한 닉네임으로 변경할 수 있다.")
+    void updateCoachSameNickName() {
+        //given
+        final String imageUrl = ".png";
+        final String nickname = "공유";
+        final String introduce = "안녕하세요. 도깨비 입니다.";
+        final String userId = "U223456789";
+
+        final Coach savedCoach = coachRepository.save(
+                new Coach("공지철", "공유", " share@woowahan.com", userId, imageUrl, "null"));
+
+        //when
+        coachService.partUpdateCoach(savedCoach.getId(), new CoachUpdateRequest(nickname, imageUrl, introduce));
+        final CoachResponse foundCoach = coachService.findCoach(savedCoach.getId());
+
+        //then
+        assertAll(
+                () -> assertThat(foundCoach.getNickname()).isEqualTo(nickname),
+                () -> assertThat(foundCoach.getIntroduce()).isEqualTo(introduce)
+        );
+
+        coachRepository.delete(savedCoach);
+    }
+
+    @Test
+    @DisplayName("slack 회원가입 후 닉네임변경 시 본인의 닉네임이 아니면서 이미 존재하는 회원 닉네임이면 예외를 반환한다.")
+    void partUpdateCrewException() {
+        // given
+        final String imageUrl = ".png";
+        final String nickname = COACH1.getNickname();
+        final String introduce = "안녕하세요. 도깨비 입니다.";
+        final String userId = "U223456789";
+
+        final Coach savedCoach = coachRepository.save(
+                new Coach("공지철", "도깨비", " share@woowahan.com", userId, imageUrl, "null"));
+
+        //when, then
+        assertThatThrownBy(() -> coachService.partUpdateCoach(savedCoach.getId(),
+                new CoachUpdateRequest(nickname, imageUrl, introduce)))
+                .isInstanceOf(InvalidMemberNicknameException.class);
 
         coachRepository.delete(savedCoach);
     }

--- a/backend/src/test/java/com/woowacourse/ternoko/service/CrewServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/ternoko/service/CrewServiceTest.java
@@ -1,10 +1,13 @@
 package com.woowacourse.ternoko.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+import com.woowacourse.ternoko.common.exception.InvalidMemberNicknameException;
 import com.woowacourse.ternoko.core.application.CrewService;
 import com.woowacourse.ternoko.core.domain.member.crew.Crew;
+import com.woowacourse.ternoko.core.domain.member.crew.CrewRepository;
 import com.woowacourse.ternoko.core.dto.request.CrewUpdateRequest;
 import com.woowacourse.ternoko.core.dto.response.CrewResponse;
 import com.woowacourse.ternoko.support.utils.DatabaseSupporter;
@@ -19,6 +22,9 @@ public class CrewServiceTest extends DatabaseSupporter {
     @Autowired
     private CrewService crewService;
 
+    @Autowired
+    private CrewRepository crewRepository;
+
     @Test
     @DisplayName("slack 회원가입 후 닉네임과 이미지를 입력받아 partUpdate 한다")
     void partUpdateCrew() {
@@ -30,11 +36,49 @@ public class CrewServiceTest extends DatabaseSupporter {
         // when
         crewService.partUpdateCrew(savedCrew.getId(), new CrewUpdateRequest(nickname, imageUrl));
         final CrewResponse updatedCrew = crewService.findCrew(savedCrew.getId());
-        // then
 
+        // then
         assertAll(
                 () -> assertThat(updatedCrew.getImageUrl()).isEqualTo(imageUrl),
                 () -> assertThat(updatedCrew.getNickname()).isEqualTo(nickname)
         );
+
+        crewRepository.deleteById(savedCrew.getId());
+    }
+
+    @Test
+    @DisplayName("slack 회원가입 후 닉네임 변경 시 본인의 닉네임으로 변경 가능하다.")
+    void partUpdateCrewSameNickName() {
+        // given
+        final Crew savedCrew = crewService.save(new Crew("엔젤앤지", "데빌앤지", "sudal@gmail.com", "U123456789", "기본이미지"));
+        final String nickname = "데빌앤지";
+        final String imageUrl = "탑건2.png";
+
+        // when
+        crewService.partUpdateCrew(savedCrew.getId(), new CrewUpdateRequest(nickname, imageUrl));
+        final CrewResponse updatedCrew = crewService.findCrew(savedCrew.getId());
+
+        // then
+        assertAll(
+                () -> assertThat(updatedCrew.getImageUrl()).isEqualTo(imageUrl),
+                () -> assertThat(updatedCrew.getNickname()).isEqualTo(nickname)
+        );
+
+        crewRepository.deleteById(savedCrew.getId());
+    }
+
+    @Test
+    @DisplayName("slack 회원가입 후 닉네임변경 시 본인의 닉네임이 아니면서 이미 존재하는 회원 닉네임이면 예외를 반환한다.")
+    void partUpdateCrewException() {
+        // given
+        final Crew savedCrew = crewService.save(new Crew("톰크루즈", null, "sudal@gmail.com", "U123456789", "기본이미지"));
+        final String existNickname = "앤지";
+        final String imageUrl = "탑건2.png";
+
+        // when, then
+        assertThatThrownBy(() ->  crewService.partUpdateCrew(savedCrew.getId(), new CrewUpdateRequest(existNickname, imageUrl)))
+                .isInstanceOf(InvalidMemberNicknameException.class);
+
+        crewRepository.deleteById(savedCrew.getId());
     }
 }

--- a/backend/src/test/java/com/woowacourse/ternoko/service/CrewServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/ternoko/service/CrewServiceTest.java
@@ -34,7 +34,7 @@ public class CrewServiceTest extends DatabaseSupporter {
         final String imageUrl = "탑건2.png";
 
         // when
-        crewService.partUpdateCrew(savedCrew.getId(), new CrewUpdateRequest(nickname, imageUrl));
+        crewService.updateCrew(savedCrew.getId(), new CrewUpdateRequest(nickname, imageUrl));
         final CrewResponse updatedCrew = crewService.findCrew(savedCrew.getId());
 
         // then
@@ -55,7 +55,7 @@ public class CrewServiceTest extends DatabaseSupporter {
         final String imageUrl = "탑건2.png";
 
         // when
-        crewService.partUpdateCrew(savedCrew.getId(), new CrewUpdateRequest(nickname, imageUrl));
+        crewService.updateCrew(savedCrew.getId(), new CrewUpdateRequest(nickname, imageUrl));
         final CrewResponse updatedCrew = crewService.findCrew(savedCrew.getId());
 
         // then
@@ -76,7 +76,7 @@ public class CrewServiceTest extends DatabaseSupporter {
         final String imageUrl = "탑건2.png";
 
         // when, then
-        assertThatThrownBy(() ->  crewService.partUpdateCrew(savedCrew.getId(), new CrewUpdateRequest(existNickname, imageUrl)))
+        assertThatThrownBy(() ->  crewService.updateCrew(savedCrew.getId(), new CrewUpdateRequest(existNickname, imageUrl)))
                 .isInstanceOf(InvalidMemberNicknameException.class);
 
         crewRepository.deleteById(savedCrew.getId());


### PR DESCRIPTION
### Issues
- [ ]  #330 

### 논의사항
- coachService, crewService에 멤버 이름 중복여부 판단하는 예외 추가했습니다.
- sql exception을 catch 후 400번대 에러를 반환 하려다가 다른 예외가 터질 때 파악하기 어려울 것 같아 검증 로직 추가하는 방향으로 진행하였습니다. 혹시 이 방법 괜찮은지 피드백 주시면 감사하겠습니다.
- custom exception 사용법 이렇게 하는게 맞는지 궁금하네요...

close #330 


