### PR TITLE
[BE] refactor: 완료한 인터뷰를 삭제할 수 있게 변경한다.

### DIFF
--- a/backend/src/main/java/com/woowacourse/ternoko/core/application/InterviewService.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/core/application/InterviewService.java
@@ -230,15 +230,15 @@ public class InterviewService {
         setDeleteMessage(interview);
     }
 
-    private void deleteComment(Long crewId, Interview interview) {
-        commentRepository.deleteByInterviewIdAndMemberId(interview.getId(), crewId);
-        commentRepository.deleteByInterviewIdAndMemberId(interview.getId(), interview.getCoach().getId());
-    }
-
     private void openAvailableDateTimeIfNotCanceled(final Interview interview) {
         if (!interview.isCanceled()) {
             interview.changeAvailableTimeStatus(OPEN);
         }
+    }
+
+    private void deleteComment(Long crewId, Interview interview) {
+        commentRepository.deleteByInterviewIdAndMemberId(interview.getId(), crewId);
+        commentRepository.deleteByInterviewIdAndMemberId(interview.getId(), interview.getCoach().getId());
     }
 
     private void deleteInterview(final Long crewId, final Interview interview) {

--- a/backend/src/main/java/com/woowacourse/ternoko/core/application/InterviewService.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/core/application/InterviewService.java
@@ -237,8 +237,8 @@ public class InterviewService {
     }
 
     private void deleteComment(Long crewId, Interview interview) {
-        commentRepository.deleteByInterviewIdAndMemberId(interview.getId(), crewId);
-        commentRepository.deleteByInterviewIdAndMemberId(interview.getId(), interview.getCoach().getId());
+        final Long coachId = interview.getCoach().getId();
+        commentRepository.deleteByInterviewIdAndMemberIds(interview, coachId, crewId);
     }
 
     private void deleteInterview(final Long crewId, final Interview interview) {

--- a/backend/src/main/java/com/woowacourse/ternoko/core/application/InterviewService.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/core/application/InterviewService.java
@@ -20,6 +20,7 @@ import com.woowacourse.ternoko.common.exception.CrewInvalidException;
 import com.woowacourse.ternoko.common.exception.InterviewInvalidException;
 import com.woowacourse.ternoko.core.domain.availabledatetime.AvailableDateTime;
 import com.woowacourse.ternoko.core.domain.availabledatetime.AvailableDateTimeRepository;
+import com.woowacourse.ternoko.core.domain.comment.CommentRepository;
 import com.woowacourse.ternoko.core.domain.interview.Interview;
 import com.woowacourse.ternoko.core.domain.interview.InterviewRepository;
 import com.woowacourse.ternoko.core.domain.interview.formitem.FormItem;
@@ -58,6 +59,7 @@ public class InterviewService {
     private final CrewRepository crewRepository;
     private final InterviewRepository interviewRepository;
     private final AvailableDateTimeRepository availableDateTimeRepository;
+    private final CommentRepository commentRepository;
     private final AlarmResponseCache cache;
 
     @Transactional(isolation = SERIALIZABLE)
@@ -223,8 +225,14 @@ public class InterviewService {
     public void delete(final Long crewId, final Long interviewId) {
         final Interview interview = getInterviewById(interviewId);
         openAvailableDateTimeIfNotCanceled(interview);
+        deleteComment(crewId, interview);
         deleteInterview(crewId, interview);
         setDeleteMessage(interview);
+    }
+
+    private void deleteComment(Long crewId, Interview interview) {
+        commentRepository.deleteByInterviewIdAndMemberId(interview.getId(), crewId);
+        commentRepository.deleteByInterviewIdAndMemberId(interview.getId(), interview.getCoach().getId());
     }
 
     private void openAvailableDateTimeIfNotCanceled(final Interview interview) {

--- a/backend/src/main/java/com/woowacourse/ternoko/core/domain/comment/CommentRepository.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/core/domain/comment/CommentRepository.java
@@ -10,11 +10,9 @@ import org.springframework.data.repository.query.Param;
 public interface CommentRepository extends JpaRepository<Comment, Long> {
     List<Comment> findByInterviewId(Long interviewId);
 
-//    void deleteByInterviewIdAndMemberId(Long interviewId, Long memberId);
-
     @Modifying(clearAutomatically = true)
     @Query("DELETE FROM Comment c WHERE c.interview = :interview and c.memberId IN (:coachId, :crewId)")
     void deleteByInterviewIdAndMemberIds(@Param("interview") final Interview interview,
-                                               @Param("coachId") final Long coachId,
-                                               @Param("crewId") final Long crewId);
+                                         @Param("coachId") final Long coachId,
+                                         @Param("crewId") final Long crewId);
 }

--- a/backend/src/main/java/com/woowacourse/ternoko/core/domain/comment/CommentRepository.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/core/domain/comment/CommentRepository.java
@@ -1,10 +1,20 @@
 package com.woowacourse.ternoko.core.domain.comment;
 
+import com.woowacourse.ternoko.core.domain.interview.Interview;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
     List<Comment> findByInterviewId(Long interviewId);
 
-    void deleteByInterviewIdAndMemberId(Long interviewId, Long memberId);
+//    void deleteByInterviewIdAndMemberId(Long interviewId, Long memberId);
+
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM Comment c WHERE c.interview = :interview and c.memberId IN (:coachId, :crewId)")
+    void deleteByInterviewIdAndMemberIds(@Param("interview") final Interview interview,
+                                               @Param("coachId") final Long coachId,
+                                               @Param("crewId") final Long crewId);
 }

--- a/backend/src/main/java/com/woowacourse/ternoko/core/domain/comment/CommentRepository.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/core/domain/comment/CommentRepository.java
@@ -5,4 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
     List<Comment> findByInterviewId(Long interviewId);
+
+    void deleteByInterviewIdAndMemberId(Long interviewId, Long memberId);
 }


### PR DESCRIPTION
### Issues
- [ ] #484 

### 논의사항
<img width="1210" alt="image" src="https://user-images.githubusercontent.com/83059234/196107336-b5fc0d6c-8340-4e01-a9ff-aeaead924d67.png">

인터뷰 삭제 시 comment 삭제가 같이 되지 않아 생긴 FK 문제였습니다!

- 현재 service에서 코멘트까지 삭제 했는데, 얘를 혹시 JPA단에서 delete cascade로 해결하는 방법 아시는분 계실까용?


## 2022-10-19 논의사항

- 완료된 인터뷰 삭제기능 넣어야할까요?
   - 현재 구현대로라면 한쪽에서 삭제하면 다른 한쪽도 삭제되는 상황입니다.
   - 또한, 코치입장에서 삭제하면 Canceled로 변하는 상황입니다.


close #484 


