### PR TITLE
[BE] refactor: 테스트시 사용하는 `h2 DB` 가 `mysql mode`로 실행되도록 수정

### DIFF
--- a/backend/src/test/java/com/woowacourse/ternoko/support/utils/DatabaseCleaner.java
+++ b/backend/src/test/java/com/woowacourse/ternoko/support/utils/DatabaseCleaner.java
@@ -1,11 +1,14 @@
 package com.woowacourse.ternoko.support.utils;
 
-import com.google.common.base.CaseFormat;
 import java.util.List;
 import java.util.stream.Collectors;
+
 import javax.persistence.EntityManager;
+
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+
+import com.google.common.base.CaseFormat;
 
 @Component
 public class DatabaseCleaner {
@@ -31,7 +34,7 @@ public class DatabaseCleaner {
         entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY FALSE").executeUpdate();
 
         for (String tableName : tableNames) {
-            entityManager.createNativeQuery("TRUNCATE TABLE " + tableName + " RESTART IDENTITY ").executeUpdate();
+            entityManager.createNativeQuery("TRUNCATE TABLE " + tableName).executeUpdate();
         }
 
         entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY TRUE").executeUpdate();

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -20,7 +20,7 @@ spring:
     generate-ddl: true
     defer-datasource-initialization: true
   datasource:
-    url:
+    url: jdbc:h2:mem:testdb;MODE=MYSQL
     username: sa
   h2:
     console:


### PR DESCRIPTION
### Issues
- [ ] #517 

### 논의사항
- 테스트에서 사용하던 h2 DB를 mysql mode 로 바꿨습니다.

- truncate 시에 h2 db에서는 sequence 전략을 사용하기 때문에 id가 초기화가 안되는데요. 그래서 truncate 시에 `RESTART IDENTITY`을 주어 id를 초기화 하는 방법을 사용했습니다.
- 근데 이 방식 외에도 h2DB를 mysql mode로 실행시키면 IDENTITY 전략을 사용해서 truncate시에도 id가 초기화가 됩니다.
- 저희가 실제 환경에서 mysql을 사용하기 때문에 mysql mode로 해결하는 것이 더 합리적이어서 적용했습니다.

close #517 


