### PR TITLE
[BE] refactor: serializable 제거 및 동시성 테스트 추가

### DIFF
--- a/.github/workflows/backend-test
+++ b/.github/workflows/backend-test
@@ -30,7 +30,7 @@ jobs:
       - name: 리포지토리를 가져옵니다
         uses: actions/checkout@v3
         with:
-          token: ${{ secrets.SUBMODULE_TOKEN }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
           submodules: recursive
 
       - name: JDK 11을 설치합니다
@@ -56,7 +56,7 @@ jobs:
         if: always()
         with:
           report_paths: '**/build/test-results/test/TEST-*.xml'
-          token: ${{ github.token }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: build 실패 시 Slack으로 알립니다
         uses: 8398a7/action-slack@v3

--- a/.github/workflows/backend-test-ci.yml
+++ b/.github/workflows/backend-test-ci.yml
@@ -36,7 +36,7 @@ jobs:
       - name: 리포지토리를 가져옵니다
         uses: actions/checkout@v3
         with:
-          token: ${{ secrets.SUBMODULE_TOKEN }}
+          token: ${{ secrets.GITHUN_TOKEN }}
           submodules: recursive
 
       - name: JDK 11을 설치합니다
@@ -62,7 +62,7 @@ jobs:
         if: always()
         with:
           report_paths: '**/build/test-results/test/TEST-*.xml'
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUN_TOKEN }}
 
       - name: build 실패 시 Slack으로 알립니다
         uses: 8398a7/action-slack@v3
@@ -81,7 +81,7 @@ jobs:
         - uses: actions/checkout@v2
           with:
             submodules: true
-            token: ${{ secrets.SUBMODULE_TOKEN }}
+            token: ${{ secrets.GITHUN_TOKEN }}
         - name: Set up JDK 11
           uses: actions/setup-java@v3
           with:
@@ -107,6 +107,7 @@ jobs:
           if: always()
           with:
             report_paths: '**/build/reports/checkstyle-result.xml'
+            token: ${{ secrets.GITHUN_TOKEN }}
 
         - name: build 실패 시 Slack으로 알립니다
           uses: 8398a7/action-slack@v3

--- a/.github/workflows/backend-test-ci.yml
+++ b/.github/workflows/backend-test-ci.yml
@@ -62,7 +62,7 @@ jobs:
         if: always()
         with:
           report_paths: '**/build/test-results/test/TEST-*.xml'
-          token: ${{ github.token }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: build 실패 시 Slack으로 알립니다
         uses: 8398a7/action-slack@v3
@@ -107,7 +107,6 @@ jobs:
           if: always()
           with:
             report_paths: '**/build/reports/checkstyle-result.xml'
-            token: ${{ github.token }}
 
         - name: build 실패 시 Slack으로 알립니다
           uses: 8398a7/action-slack@v3

--- a/.github/workflows/backend-test-ci.yml
+++ b/.github/workflows/backend-test-ci.yml
@@ -36,7 +36,7 @@ jobs:
       - name: 리포지토리를 가져옵니다
         uses: actions/checkout@v3
         with:
-          token: ${{ secrets.GITHUN_TOKEN }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
           submodules: recursive
 
       - name: JDK 11을 설치합니다
@@ -62,7 +62,7 @@ jobs:
         if: always()
         with:
           report_paths: '**/build/test-results/test/TEST-*.xml'
-          token: ${{ secrets.GITHUN_TOKEN }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: build 실패 시 Slack으로 알립니다
         uses: 8398a7/action-slack@v3
@@ -107,7 +107,7 @@ jobs:
           if: always()
           with:
             report_paths: '**/build/reports/checkstyle-result.xml'
-            token: ${{ secrets.GITHUN_TOKEN }}
+            repo-token: ${{ secrets.GITHUB_TOKEN }}
 
         - name: build 실패 시 Slack으로 알립니다
           uses: 8398a7/action-slack@v3

--- a/.github/workflows/backend-test-ci.yml
+++ b/.github/workflows/backend-test-ci.yml
@@ -36,7 +36,7 @@ jobs:
       - name: 리포지토리를 가져옵니다
         uses: actions/checkout@v3
         with:
-          token: ${{ secrets.SUBMODULE_TOKEN }}
+          token: ${{ secrets.GITHUN_TOKEN }}
           submodules: recursive
 
       - name: JDK 11을 설치합니다
@@ -62,7 +62,7 @@ jobs:
         if: always()
         with:
           report_paths: '**/build/test-results/test/TEST-*.xml'
-          token: ${{ github.token }}
+          token: ${{ secrets.GITHUN_TOKEN }}
 
       - name: build 실패 시 Slack으로 알립니다
         uses: 8398a7/action-slack@v3
@@ -81,7 +81,7 @@ jobs:
         - uses: actions/checkout@v2
           with:
             submodules: true
-            token: ${{ secrets.SUBMODULE_TOKEN }}
+            token: ${{ secrets.GITHUN_TOKEN }}
         - name: Set up JDK 11
           uses: actions/setup-java@v3
           with:
@@ -107,7 +107,7 @@ jobs:
           if: always()
           with:
             report_paths: '**/build/reports/checkstyle-result.xml'
-            token: ${{ github.token }}
+            token: ${{ secrets.GITHUN_TOKEN }}
 
         - name: build 실패 시 Slack으로 알립니다
           uses: 8398a7/action-slack@v3

--- a/.github/workflows/backend-test-ci.yml
+++ b/.github/workflows/backend-test-ci.yml
@@ -36,7 +36,7 @@ jobs:
       - name: 리포지토리를 가져옵니다
         uses: actions/checkout@v3
         with:
-          token: ${{ secrets.GITHUN_TOKEN }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
           submodules: recursive
 
       - name: JDK 11을 설치합니다
@@ -62,7 +62,7 @@ jobs:
         if: always()
         with:
           report_paths: '**/build/test-results/test/TEST-*.xml'
-          token: ${{ secrets.GITHUN_TOKEN }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: build 실패 시 Slack으로 알립니다
         uses: 8398a7/action-slack@v3
@@ -81,7 +81,7 @@ jobs:
         - uses: actions/checkout@v2
           with:
             submodules: true
-            token: ${{ secrets.GITHUN_TOKEN }}
+            repo-token: ${{ secrets.GITHUB_TOKEN }}
         - name: Set up JDK 11
           uses: actions/setup-java@v3
           with:
@@ -107,7 +107,7 @@ jobs:
           if: always()
           with:
             report_paths: '**/build/reports/checkstyle-result.xml'
-            token: ${{ secrets.GITHUN_TOKEN }}
+            repo-token: ${{ secrets.GITHUB_TOKEN }}
 
         - name: build 실패 시 Slack으로 알립니다
           uses: 8398a7/action-slack@v3

--- a/backend/src/main/java/com/woowacourse/ternoko/core/application/InterviewService.java
+++ b/backend/src/main/java/com/woowacourse/ternoko/core/application/InterviewService.java
@@ -1,18 +1,18 @@
 package com.woowacourse.ternoko.core.application;
 
-import static com.woowacourse.ternoko.common.exception.ExceptionType.AVAILABLE_DATE_TIME_NOT_FOUND;
-import static com.woowacourse.ternoko.common.exception.ExceptionType.COACH_NOT_FOUND;
-import static com.woowacourse.ternoko.common.exception.ExceptionType.CREW_NOT_FOUND;
-import static com.woowacourse.ternoko.common.exception.ExceptionType.INTERVIEW_NOT_FOUND;
-import static com.woowacourse.ternoko.common.exception.ExceptionType.INVALID_INTERVIEW_BY_MEMBER;
-import static com.woowacourse.ternoko.common.exception.ExceptionType.INVALID_INTERVIEW_CREW_ID;
-import static com.woowacourse.ternoko.common.exception.ExceptionType.INVALID_INTERVIEW_DUPLICATE_DATE_TIME;
-import static com.woowacourse.ternoko.common.exception.ExceptionType.USED_BY_OTHER;
-import static com.woowacourse.ternoko.core.domain.availabledatetime.AvailableDateTimeStatus.OPEN;
-import static com.woowacourse.ternoko.core.domain.availabledatetime.AvailableDateTimeStatus.USED;
-import static com.woowacourse.ternoko.core.domain.interview.InterviewStatusType.isCanceled;
+import static com.woowacourse.ternoko.common.exception.ExceptionType.*;
+import static com.woowacourse.ternoko.core.domain.availabledatetime.AvailableDateTimeStatus.*;
+import static com.woowacourse.ternoko.core.domain.interview.InterviewStatusType.*;
 import static java.lang.Long.valueOf;
-import static org.springframework.transaction.annotation.Isolation.SERIALIZABLE;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.woowacourse.ternoko.common.exception.AvailableDateTimeInvalidException;
 import com.woowacourse.ternoko.common.exception.CoachInvalidException;
@@ -34,14 +34,8 @@ import com.woowacourse.ternoko.core.dto.response.ScheduleResponse;
 import com.woowacourse.ternoko.support.alarm.AlarmResponse;
 import com.woowacourse.ternoko.support.alarm.AlarmResponseCache;
 import com.woowacourse.ternoko.support.alarm.SlackMessageType;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.util.Comparator;
-import java.util.List;
-import java.util.stream.Collectors;
+
 import lombok.AllArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Transactional
@@ -60,7 +54,7 @@ public class InterviewService {
     private final AvailableDateTimeRepository availableDateTimeRepository;
     private final AlarmResponseCache cache;
 
-    @Transactional(isolation = SERIALIZABLE)
+    @Transactional
     public Long create(final Long crewId, final InterviewRequest interviewRequest) {
         final Interview interview = convertInterview(crewId, interviewRequest);
         validateDuplicateStartTimeByCrew(interviewRequest.getInterviewDatetime(), crewId);

--- a/backend/src/test/java/com/woowacourse/ternoko/service/InterviewServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/ternoko/service/InterviewServiceTest.java
@@ -1,36 +1,31 @@
 package com.woowacourse.ternoko.service;
 
-import static com.woowacourse.ternoko.common.exception.ExceptionType.INVALID_INTERVIEW_DATE;
-import static com.woowacourse.ternoko.core.domain.availabledatetime.AvailableDateTimeStatus.DELETED;
-import static com.woowacourse.ternoko.core.domain.availabledatetime.AvailableDateTimeStatus.OPEN;
-import static com.woowacourse.ternoko.support.fixture.MemberFixture.COACH1;
-import static com.woowacourse.ternoko.support.fixture.refactor.AvailableDateTimeFixture._2022_07_01_10_00;
-import static com.woowacourse.ternoko.support.fixture.refactor.AvailableDateTimeFixture.면담가능시간_브리_2022_07_01_10_00;
-import static com.woowacourse.ternoko.support.fixture.refactor.AvailableDateTimeFixture.면담가능시간_준_2022_07_01_10_00;
-import static com.woowacourse.ternoko.support.fixture.refactor.AvailableDateTimeFixture.면담가능시간_준_2022_07_01_11_00;
-import static com.woowacourse.ternoko.support.fixture.refactor.AvailableDateTimeFixture.면담가능시간_준_2022_07_01_12_00;
-import static com.woowacourse.ternoko.support.fixture.refactor.AvailableDateTimeFixture.면담가능시간_토미_2022_07_01_10_00;
-import static com.woowacourse.ternoko.support.fixture.refactor.AvailableDateTimeFixture.면담가능시간_토미_2022_07_01_11_00;
-import static com.woowacourse.ternoko.support.fixture.refactor.AvailableDateTimeFixture.면담가능시간_토미_2022_07_01_12_00;
-import static com.woowacourse.ternoko.support.fixture.refactor.AvailableDateTimeFixture.면담가능시간생성요청정보_2022_07_01_10_TO_12;
-import static com.woowacourse.ternoko.support.fixture.refactor.AvailableDateTimeFixture.면담가능시간생성요청정보_2022_07_02_10_TO_12;
-import static com.woowacourse.ternoko.support.fixture.refactor.InterviewFixture.면담사전질문요청정보들;
-import static com.woowacourse.ternoko.support.fixture.refactor.InterviewFixture.면담생성요청정보_준_2022_07_01_10_00;
-import static com.woowacourse.ternoko.support.fixture.refactor.InterviewFixture.면담생성요청정보_토미_2022_07_01_10_00;
-import static com.woowacourse.ternoko.support.fixture.refactor.MemberFixture.김록바;
-import static com.woowacourse.ternoko.support.fixture.refactor.MemberFixture.김애쉬;
-import static com.woowacourse.ternoko.support.fixture.refactor.MemberFixture.네오;
-import static com.woowacourse.ternoko.support.fixture.refactor.MemberFixture.브리;
-import static com.woowacourse.ternoko.support.fixture.refactor.MemberFixture.손앤지;
-import static com.woowacourse.ternoko.support.fixture.refactor.MemberFixture.준;
-import static com.woowacourse.ternoko.support.fixture.refactor.MemberFixture.토미;
-import static com.woowacourse.ternoko.support.fixture.refactor.MemberFixture.허수달;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doNothing;
+import static com.woowacourse.ternoko.common.exception.ExceptionType.*;
+import static com.woowacourse.ternoko.core.domain.availabledatetime.AvailableDateTimeStatus.*;
+import static com.woowacourse.ternoko.support.fixture.MemberFixture.*;
+import static com.woowacourse.ternoko.support.fixture.refactor.AvailableDateTimeFixture.*;
+import static com.woowacourse.ternoko.support.fixture.refactor.InterviewFixture.*;
+import static com.woowacourse.ternoko.support.fixture.refactor.MemberFixture.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.mock.mockito.MockBean;
 
 import com.woowacourse.ternoko.common.exception.AvailableDateTimeInvalidException;
 import com.woowacourse.ternoko.common.exception.InterviewInvalidException;
@@ -48,20 +43,6 @@ import com.woowacourse.ternoko.support.alarm.AlarmResponseCache;
 import com.woowacourse.ternoko.support.alarm.SlackAlarm;
 import com.woowacourse.ternoko.support.time.TimeMachine;
 import com.woowacourse.ternoko.support.utils.DatabaseSupporter;
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.stream.Collectors;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
-import org.springframework.boot.test.mock.mockito.MockBean;
 
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 class InterviewServiceTest extends DatabaseSupporter {
@@ -530,22 +511,31 @@ class InterviewServiceTest extends DatabaseSupporter {
     }
 
     @Test
-    @Disabled
-    @DisplayName("같은 가능 시간에 여러개의 면담을 생성할 수 없다. (동시성테스트)")
-    void test_concurrent() {
+    @DisplayName("한 코치의 하나의 면담 가능 시간으로 동시에 여러개의 면담을 생성할 수 없다. - 동시성테스트")
+    void concurrentCreate() throws InterruptedException {
+        final int numberOfThreads = 2;
+        final ExecutorService service = Executors.newFixedThreadPool(numberOfThreads);
+        final CountDownLatch start = new CountDownLatch(numberOfThreads);
+        final CountDownLatch end = new CountDownLatch(numberOfThreads);
         coachService.putAvailableDateTimesByCoachId(준.getId(), 면담가능시간생성요청정보_2022_07_01_10_TO_12);
-        ExecutorService service = Executors.newCachedThreadPool();
 
-        for (Long i = 5L; i <= 6L; i++) {
-            final Long finalI = i;
+        for (long i = 5L; i < 5 + numberOfThreads; i++) {
+            final long finalI = i;
             service.execute(() -> {
                 try {
+                    start.countDown();
+                    start.await();
                     interviewService.create(finalI, 면담생성요청정보_준_2022_07_01_10_00);
-                } catch (Exception e) {
+                } catch (InterruptedException e) {
                     e.printStackTrace();
+                } finally {
+                    end.countDown();
                 }
             });
         }
+        end.await();
+        final ScheduleResponse response = interviewService.findAllByCoach(준.getId(), 2022, 7);
+        assertThat(response.getCalendar()).hasSize(1);
     }
 
     private void 현재시간_설정(final int year, final int month, final int day, final int hour, final int minute) {


### PR DESCRIPTION
### Issues
- [ ] #510 

### 논의사항
- 상황별 동시성 테스트 결과 포함합니다!
## 동시성 테스트

코드

```java
@Test
@DisplayName("한 코치의 하나의 면담 가능 시간으로 동시에 여러개의 면담을 생성할 수 없다. - 동시성")
void concurrentCreate() throws InterruptedException {
    final int numberOfThreads = 2;
    final ExecutorService service = Executors.newFixedThreadPool(numberOfThreads);
    final CountDownLatch start = new CountDownLatch(numberOfThreads);
    final CountDownLatch end = new CountDownLatch(numberOfThreads);
    coachService.putAvailableDateTimesByCoachId(준.getId(), 면담가능시간생성요청정보_2022_07_01_10_TO_12);

    for (long i = 5L; i < 5 + numberOfThreads; i++) {
        final long finalI = i;
        service.execute(() -> {
            try {
                start.countDown();
                start.await();
                interviewService.create(finalI, 면담생성요청정보_준_2022_07_01_10_00);
            } catch (InterruptedException e) {
                e.printStackTrace();
            } finally {
                end.countDown();
            }
        });
    }
    end.await();
    final ScheduleResponse response = interviewService.findAllByCoach(준.getId(), 2022, 7);
    assertThat(response.getCalendar()).hasSize(1);
}
```

### 1. serializable + not unique

데드락이 발생합니다.

![image](https://user-images.githubusercontent.com/54317630/200113653-8fb21689-ca92-4adf-8e03-bf49b20fb604.png)

innoDB의 serializable은 기본적으로 모든 단순읽기에도 s lock을 걸기때문에

인터뷰가 생성될때

1. tx1 이 availableDateTime의 레코드를 읽으며 s lock을 걸고
tx2 가 availableDateTIme의 레코드를 읽으며 s lock을 건다.
2. tx1이 availableDateTime 을 수정하려고 x lock을 걸때 tx2의 s lock 때문에 기다린다.
tx2이 availableDateTime 을 수정하려고 x lock을 걸때 tx1의 s lock 때문에 기다린다.

이러한 문제로 데드락이 발생합니다. 
-> 틀린 설명

현재 테스트코드는 H2로 돌아가는데 H2 의 serializable은 innoDB처럼 돌아가지 않습니다. (읽기에 slock을 거는 것이 아닙니다)
그럼 데드락이 왜 터질까?

### 2. repeatable read + not unique

동시성 문제가 발생합니다.

unique가 걸려있지 않기 때문에 2개의 Interview가 동시에 생성이 되었습니다.

![image](https://user-images.githubusercontent.com/54317630/200113664-3eba5ec6-e8ad-4b6d-8e91-a02f65490a8f.png)


### 3. repleatable read + unique

unique 제약조건으로 DB에러가 터집니다.

```java
Caused by: org.h2.jdbc.JdbcSQLIntegrityConstraintViolationException: Unique index or primary key violation: "PUBLIC.UK_89AEH6C8PV4YAQSUYDVIE7QE_INDEX_C ON PUBLIC.INTERVIEW(AVAILABLE_DATE_TIME_ID NULLS FIRST) VALUES ( /* 1 */ CAST(1 AS BIGINT) )"; SQL statement:
insert into interview (id, available_date_time_id, coach_id, crew_id, interview_end_time, interview_start_time, interview_status_type) values (default, ?, ?, ?, ?, ?, ?) [23505-214]
```

동시에 Interview가 생기지 않기 때문에 이대로 해결하는 방식이 좋아 보입니다.

DB에러이기 때문에 500에러가 터지는데 500 에러로 두는 것과 400에러로 바꾸는 방식중에는 회의를 해봐야할 것 같습니다!

close #510 


